### PR TITLE
Restore mock fallback for RLS-affected tables

### DIFF
--- a/js/lib/supa.js
+++ b/js/lib/supa.js
@@ -88,36 +88,19 @@ function handleError(error, context = 'Operación') {
  * Helper genérico para SELECT con manejo de errores
  */
 export async function selectData(table, options = {}) {
-        // Datos mock temporales para tablas con problemas de RLS
-        const mockData = {
-            'areas': [
-                {
-                    id: 1,
-                    clave: 'OPERACIONES',
-                    nombre: 'Operaciones Aeroportuarias',
-                    descripcion: 'Indicadores de operaciones del aeropuerto',
-                    color_hex: '#3B82F6',
-                    estado: 'ACTIVO'
-                },
-                {
-                    id: 2,
-                    clave: 'SEGURIDAD', 
-                    nombre: 'Seguridad y Protección',
-                    descripcion: 'Indicadores de seguridad aeroportuaria',
-                    color_hex: '#EF4444',
-                    estado: 'ACTIVO'
-                }
-            ],
-            'perfiles': [],
-            'usuario_areas': [],
-            'indicadores': []
-        };
-        
-        // Si la tabla tiene problemas conocidos, devolver datos mock
-        if (mockData[table]) {
-            if (DEBUG.enabled) console.log(`🔧 Usando datos mock para ${table}`);
-            return { data: mockData[table], count: mockData[table].length };
-        }
+    // Datos mock temporales para tablas con problemas de RLS
+    const mockData = {
+        perfiles: [],
+        usuario_areas: [],
+        indicadores: []
+    };
+
+    const hasMockForTable = Object.prototype.hasOwnProperty.call(mockData, table);
+    // Si la tabla tiene problemas conocidos, devolver datos mock
+    if (hasMockForTable) {
+        if (DEBUG.enabled) console.log(`🔧 Usando datos mock para ${table}`);
+        return { data: mockData[table], count: mockData[table].length };
+    }
     try {
         if (DEBUG.enabled) console.log(`🔍 SELECT ${table}:`, options);
         


### PR DESCRIPTION
## Summary
- keep the mock selectData fallback for perfiles, usuario_areas, and indicadores so RLS-recursion issues are avoided
- continue omitting areas from the mock dataset so that selectData('areas', …) always queries Supabase

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8424d7d7c832e9f736302b011d781