### PR TITLE
Fix selectData try/catch structure

### DIFF
--- a/js/lib/supa.js
+++ b/js/lib/supa.js
@@ -108,26 +108,18 @@ export async function selectData(table, options = {}) {
     } : null;
 
     const hasMockForTable = devMode && mockData && Object.prototype.hasOwnProperty.call(mockData, table);
-    try {
-           // Datos mock temporales para tablas con problemas de RLS
-        const mockData = {
-            perfiles: [],
-            usuario_areas: [],
-            indicadores: []
-        };
 
-        const hasMockForTable = Object.prototype.hasOwnProperty.call(mockData, table);
-        // Si la tabla tiene problemas conocidos, devolver datos mock
+    try {
         if (hasMockForTable) {
             if (DEBUG.enabled) console.log(`🔧 Usando datos mock para ${table}`);
-            return { data: mockData[table], count: mockData[table].length };
-        } 
-        try {
+            const data = mockData?.[table] ?? [];
+            return { data, count: Array.isArray(data) ? data.length : null };
+        }
 
-          if (DEBUG.enabled) console.log(`🔍 SELECT ${table}:`, options);
+        if (DEBUG.enabled) console.log(`🔍 SELECT ${table}:`, options);
 
         let query = supabase.from(table).select(options.select || '*');
-        
+
         // Aplicar filtros
         if (options.filters) {
             Object.entries(options.filters).forEach(([column, value]) => {
@@ -166,46 +158,36 @@ export async function selectData(table, options = {}) {
                 }
             });
         }
-        
+
         // Aplicar ordenamiento
-        /*if (options.orderBy) {
+        if (options.orderBy) {
             if (Array.isArray(options.orderBy)) {
                 options.orderBy.forEach(order => {
-                    query = query.order(order.column, { ascending: order.ascending !== false });
+                    if (typeof order === 'string') {
+                        query = query.order(order, { ascending: true });
+                    } else {
+                        query = query.order(order.column, { ascending: order.ascending !== false });
+                    }
                 });
-            } else {
+            } else if (typeof options.orderBy === 'string') {
                 query = query.order(options.orderBy, { ascending: options.ascending !== false });
+            } else if (options.orderBy.column) {
+                query = query.order(options.orderBy.column, { ascending: options.orderBy.ascending !== false });
             }
-        }*/
+        }
 
-            if (options.orderBy) {
-                if (Array.isArray(options.orderBy)) {
-                    options.orderBy.forEach(order => {
-                        if (typeof order === 'string') {
-                            query = query.order(order, { ascending: true });
-                        } else {
-                            query = query.order(order.column, { ascending: order.ascending !== false });
-                        }
-                    });
-                } else if (typeof options.orderBy === 'string') {
-                    query = query.order(options.orderBy, { ascending: options.ascending !== false });
-                } else if (options.orderBy.column) {
-                    query = query.order(options.orderBy.column, { ascending: options.orderBy.ascending !== false });
-                }
-            }
-        
         // Aplicar límite
         if (options.limit) {
             query = query.limit(options.limit);
         }
-        
+
         // Aplicar rango (paginación)
         if (options.from !== undefined && options.to !== undefined) {
             query = query.range(options.from, options.to);
         }
-        
+
         const { data, error, count } = await query;
-        
+
         if (error) {
             console.error(`❌ Error en SELECT ${table}:`, error);
             throw new SupabaseError(error.message, error.code, error.details);


### PR DESCRIPTION
## Summary
- remove a stray nested try block in `selectData` and clean up the query-building flow
- ensure mock data fallback returns consistent counts when used for development tables

## Testing
- node --check js/lib/supa.js
- node --input-type=module <<'NODE'
class QueryMock {
  constructor(result) {
    this.result = result;
  }
  select() {
    return this;
  }
  in() {
    return this;
  }
  eq() {
    return this;
  }
  ilike() {
    return this;
  }
  like() {
    return this;
  }
  gte() {
    return this;
  }
  lte() {
    return this;
  }
  neq() {
    return this;
  }
  gt() {
    return this;
  }
  lt() {
    return this;
  }
  order() {
    return this;
  }
  limit() {
    return this;
  }
  range() {
    return this;
  }
  then(resolve, reject) {
    return Promise.resolve(this.result).then(resolve, reject);
  }
  catch(reject) {
    return Promise.resolve(this.result).catch(reject);
  }
  finally(onFinally) {
    return Promise.resolve(this.result).finally(onFinally);
  }
}

const supabaseMock = {
  from() {
    return new QueryMock({ data: [], error: null, count: 0 });
  },
  rpc: async () => ({ data: null, error: null }),
  auth: {
    onAuthStateChange(callback) {
      // Simular suscripción sin disparar eventos
      return { data: { subscription: { unsubscribe() {} } } };
    },
    async getSession() {
      return { data: { session: null }, error: null };
    },
    async getUser() {
      return { data: { user: null }, error: null };
    },
    async signInWithPassword() {
      return {
        data: {
          user: { id: 'user-1', email: 'test@example.com' },
          session: { access_token: 'token' }
        },
        error: null
      };
    },
    async signOut() {
      return { error: null };
    }
  }
};

global.window = { supabaseClient: supabaseMock };

const mod = await import('./js/lib/supa.js');
await mod.initSupabase();
console.log('Supabase initialized in test environment');
NODE

------
https://chatgpt.com/codex/tasks/task_e_68c87b0fa090832e9d69d7edd11f6d9c