### PR TITLE
Ordena mediciones historicas por mes

### DIFF
--- a/js/views/panel-directivos.js
+++ b/js/views/panel-directivos.js
@@ -505,7 +505,10 @@ async function cargarDatosReales(indicador) {
     try {
         const { data, error } = await selectData('v_mediciones_historico', {
             filters: { indicador_id: indicador.id },
-            orderBy: { column: 'anio', ascending: true }
+            orderBy: [
+                { column: 'anio', ascending: true },
+                { column: 'mes', ascending: true }
+            ]
         });
         
         if (error) throw error;
@@ -514,7 +517,10 @@ async function cargarDatosReales(indicador) {
             ...d,
             fecha: `${d.anio}-${String(d.mes).padStart(2, '0')}-01`,
             valor: d.valor
-        }));
+        })).sort((a, b) => {
+            if (a.anio !== b.anio) return a.anio - b.anio;
+            return a.mes - b.mes;
+        });
         
         if (DEBUG.enabled) console.log('📊 Datos reales cargados:', panelState.datosReales.length);
         


### PR DESCRIPTION
## Summary
- ordena los resultados históricos por año y mes al consultarlos para el panel de directivos
- asegura que los datos reales se ordenen también en el cliente para mantener la secuencia cronológica

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d56b8f7d24832e8be31fb512b5ff1c