### PR TITLE
Corrige valores del último mes en panel directivos

### DIFF
--- a/js/lib/charts.js
+++ b/js/lib/charts.js
@@ -232,7 +232,14 @@ async function crearGraficaHistorica(canvasId, datos, opciones = {}) {
         const datasets = aniosSeleccionados.map(anio => {
             const yearData = crearArrayMeses(null);
             datos.filter(d => new Date(d.fecha).getFullYear() === anio).forEach(d => {
-                yearData[new Date(d.fecha).getMonth()] = d.valor;
+                const mesIndex = new Date(d.fecha).getMonth();
+                const valor = d.valor === null || d.valor === undefined ? null : Number(d.valor);
+
+                if (!Number.isFinite(valor)) {
+                    return;
+                }
+
+                yearData[mesIndex] = valor;
             });
             return { label: anio.toString(), data: yearData, borderColor: obtenerColorPorAnio(anio) };
         });

--- a/js/views/panel-directivos.js
+++ b/js/views/panel-directivos.js
@@ -505,19 +505,126 @@ async function cargarDatosReales(indicador) {
     try {
         const { data, error } = await selectData('v_mediciones_historico', {
             filters: { indicador_id: indicador.id },
-            orderBy: { column: 'anio', ascending: true }
+            orderBy: [
+                { column: 'anio', ascending: true },
+                { column: 'mes', ascending: true }
+            ]
         });
-        
+
         if (error) throw error;
-        
-        panelState.datosReales = (data || []).map(d => ({
-            ...d,
-            fecha: `${d.anio}-${String(d.mes).padStart(2, '0')}-01`,
-            valor: d.valor
-        }));
-        
+
+        const normalizarValor = valorOriginal => {
+            if (valorOriginal === null || valorOriginal === undefined) return null;
+
+            if (typeof valorOriginal === 'number') {
+                return Number.isFinite(valorOriginal) ? valorOriginal : null;
+            }
+
+            if (typeof valorOriginal === 'string') {
+                const limpio = valorOriginal.trim();
+                if (limpio === '') return null;
+
+                // Eliminar símbolos no numéricos excepto separadores decimales
+                const soloNumeros = limpio.replace(/[^0-9.,-]/g, '');
+                if (soloNumeros === '') return null;
+
+                const tieneComa = soloNumeros.includes(',');
+                const tienePunto = soloNumeros.includes('.');
+                let valorNormalizado = soloNumeros;
+
+                if (tieneComa && tienePunto) {
+                    // Determinar cuál es el separador decimal usando la última aparición
+                    const ultimaComa = soloNumeros.lastIndexOf(',');
+                    const ultimoPunto = soloNumeros.lastIndexOf('.');
+
+                    if (ultimaComa > ultimoPunto) {
+                        // Formato tipo 1.234,56 -> quitar puntos (miles) y usar coma como decimal
+                        valorNormalizado = soloNumeros.replace(/\./g, '').replace(/,/g, '.');
+                    } else {
+                        // Formato tipo 1,234.56 -> quitar comas (miles)
+                        valorNormalizado = soloNumeros.replace(/,/g, '');
+                    }
+                } else if (tieneComa && !tienePunto) {
+                    // Formato tipo 1234,56 -> usar coma como decimal
+                    valorNormalizado = soloNumeros.replace(/,/g, '.');
+                } else {
+                    // Formato tipo 1 234.56 -> quitar posibles separadores de miles
+                    valorNormalizado = soloNumeros.replace(/,/g, '');
+                }
+
+                const numero = Number(valorNormalizado);
+                return Number.isFinite(numero) ? numero : null;
+            }
+
+            return null;
+        };
+
+        const obtenerMarcaDeTiempo = registro => {
+            const candidatas = [
+                registro.fecha_ultima_edicion,
+                registro.fecha_captura,
+                registro.fecha_medicion,
+                registro.fecha
+            ].filter(Boolean);
+
+            if (candidatas.length === 0) return 0;
+
+            const maxFecha = candidatas.reduce((max, fecha) => {
+                const time = new Date(fecha).getTime();
+                return Number.isFinite(time) && time > max ? time : max;
+            }, 0);
+
+            return maxFecha;
+        };
+
+        const registrosOrdenados = (data || [])
+            .map(d => {
+                const valorNormalizado = normalizarValor(d.valor);
+                const mesNumerico = typeof d.mes === 'string' ? Number(d.mes) : d.mes;
+                const anioNumerico = typeof d.anio === 'string' ? Number(d.anio) : d.anio;
+                const fechaPeriodo = `${anioNumerico}-${String(mesNumerico).padStart(2, '0')}-01`;
+
+                return {
+                    ...d,
+                    mes: mesNumerico,
+                    anio: anioNumerico,
+                    fecha: fechaPeriodo,
+                    valor: valorNormalizado,
+                    _timestamp: obtenerMarcaDeTiempo({ ...d, fecha: fechaPeriodo })
+                };
+            })
+            .filter(registro => registro.valor !== null && registro.valor !== undefined)
+            .sort((a, b) => {
+                if (a.anio !== b.anio) return a.anio - b.anio;
+                if (a.mes !== b.mes) return a.mes - b.mes;
+                return a._timestamp - b._timestamp;
+            });
+
+        const registrosPorPeriodo = new Map();
+
+        for (const registro of registrosOrdenados) {
+            const clavePeriodo = `${registro.anio}-${String(registro.mes).padStart(2, '0')}`;
+            const existente = registrosPorPeriodo.get(clavePeriodo);
+
+            if (!existente) {
+                registrosPorPeriodo.set(clavePeriodo, registro);
+                continue;
+            }
+
+            if (registro._timestamp >= existente._timestamp) {
+                registrosPorPeriodo.set(clavePeriodo, registro);
+            }
+        }
+
+        panelState.datosReales = Array.from(registrosPorPeriodo.values())
+            .sort((a, b) => {
+                if (a.anio !== b.anio) return a.anio - b.anio;
+                return a.mes - b.mes;
+            })
+            .map(({ _timestamp, ...registro }) => registro);
+
         if (DEBUG.enabled) console.log('📊 Datos reales cargados:', panelState.datosReales.length);
-        
+
     } catch (error) {
         console.error('❌ Error al cargar datos reales:', error);
         throw error;
@@ -554,9 +661,13 @@ async function cargarDatosMetas(indicador, escenario) {
 
 function obtenerUltimoMesConDatos() {
     if (panelState.datosReales.length === 0) return null;
-    
-    const ultimoRegistro = panelState.datosReales[panelState.datosReales.length - 1];
-    
+
+    const ultimoRegistro = [...panelState.datosReales]
+        .reverse()
+        .find(registro => registro.valor !== null && registro.valor !== undefined);
+
+    if (!ultimoRegistro) return null;
+
     return {
         mes: ultimoRegistro.mes,
         año: ultimoRegistro.anio,


### PR DESCRIPTION
## Summary
- normaliza los valores históricos permitiendo formatos con comas y puntos para evitar descartar mediciones válidas
- selecciona el registro más reciente por periodo usando marcas de tiempo de captura y edición antes de alimentar la tabla y gráficas

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d56b8f7d24832e8be31fb512b5ff1c