### PR TITLE
Ajustar navegación y cuenta según sesión y rol

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,7 +120,8 @@
           <div>
             <h1 class="text-xl font-bold text-gray-900">Sistema de Indicadores AIFA</h1>
             <p class="text-xs leading-tight text-gray-600 sm:text-sm sm:leading-snug whitespace-normal max-w-xs sm:max-w-md">
-              Aeropuerto Internacional Felipe Ángeles
+              <span class="block sm:inline">Aeropuerto Internacional</span>
+              <span class="block sm:inline sm:ml-1">Felipe Ángeles</span>
             </p>
           </div>
         </div>
@@ -152,7 +153,7 @@
             <div class="text-xs text-gray-600" id="user-role">Rol</div>
           </div>
           <button id="user-menu-button" class="flex items-center gap-2 px-3 py-2 rounded-lg text-gray-600 bg-white hover:bg-gray-100">
-            <i data-lucide="user" class="w-4 h-4"></i><span class="hidden sm:inline">Cuenta</span>
+            <i data-lucide="user" class="w-4 h-4"></i><span id="user-menu-label" class="text-sm font-medium text-gray-700 max-w-[10rem] truncate">Cuenta</span>
           </button>
         </div>
       </div>

--- a/js/app/bootstrap.js
+++ b/js/app/bootstrap.js
@@ -7,7 +7,7 @@ import { DEBUG } from '../config.js';
 import { routes, getNavigationBindings } from './routes.js';
 import { initRouter, navigateTo, goBack, reloadCurrentRoute, parseCurrentRoute, getDefaultRouteForUser } from '../lib/router.js';
 import * as ui from '../lib/ui.js';
-import { initSupabase, appState, getCurrentProfile, onAuthStateChange, isAuthenticated, signOut } from '../lib/supa.js';
+import { initSupabase, appState, getCurrentProfile, onAuthStateChange, isAuthenticated, signOut, changePassword } from '../lib/supa.js';
 
 // =====================================================
 // UTILIDADES
@@ -65,22 +65,66 @@ function setupNavigation() {
     });
 }
 
+function updateNavigationVisibility() {
+    const navigation = document.querySelector('header nav');
+    if (!navigation) return;
+
+    const navButtons = {
+        home: document.getElementById('nav-home'),
+        visualizacion: document.getElementById('nav-visualizacion'),
+        captura: document.getElementById('nav-captura'),
+        admin: document.getElementById('nav-admin'),
+        panelDirectivos: document.getElementById('nav-panel-directivos')
+    };
+
+    if (!appState.user || !appState.profile) {
+        navigation.style.display = 'none';
+        return;
+    }
+
+    navigation.style.display = '';
+
+    Object.values(navButtons).forEach(button => {
+        if (button) {
+            button.classList.remove('hidden');
+        }
+    });
+
+    if (appState.profile?.rol_principal === 'DIRECTOR') {
+        ['nav-home', 'nav-captura', 'nav-admin'].forEach(id => {
+            const button = document.getElementById(id);
+            if (button) {
+                button.classList.add('hidden');
+            }
+        });
+    }
+}
+
 function updateUserHeader() {
     const userInfo = document.getElementById('user-info');
     const userName = document.getElementById('user-name');
     const userRole = document.getElementById('user-role');
+    const userMenuLabel = document.getElementById('user-menu-label');
 
     const { user, profile } = appState;
 
     if (user && profile) {
+        const displayName = profile.nombre_completo?.trim()
+            || appState.user?.user_metadata?.full_name
+            || appState.user?.email
+            || 'Usuario';
+
         if (userInfo) {
             userInfo.classList.remove('hidden');
         }
         if (userName) {
-            userName.textContent = profile.nombre_completo || user.email || 'Usuario';
+            userName.textContent = displayName;
         }
         if (userRole) {
             userRole.textContent = getRoleLabel(profile.rol_principal);
+        }
+        if (userMenuLabel) {
+            userMenuLabel.textContent = displayName;
         }
     } else {
         if (userInfo) {
@@ -92,7 +136,12 @@ function updateUserHeader() {
         if (userRole) {
             userRole.textContent = '';
         }
+        if (userMenuLabel) {
+            userMenuLabel.textContent = 'Iniciar sesión';
+        }
     }
+
+    updateNavigationVisibility();
 }
 
 async function openUserMenu() {
@@ -158,12 +207,18 @@ async function openUserMenu() {
                 <div class="grid gap-4">
                     ${infoFields.map(renderInfoField).join('')}
                 </div>
-                <div class="flex items-center justify-between gap-3 border-t border-gray-100 pt-4">
+                <div class="flex flex-col gap-3 border-t border-gray-100 pt-4 sm:flex-row sm:items-center sm:justify-between">
                     <p class="text-xs leading-snug text-gray-500">Gestiona tu sesión desde esta ventana.</p>
-                    <button id="logout-btn-modal" class="inline-flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 px-4 py-2 text-sm font-medium text-red-600 transition hover:bg-red-100">
-                        <i data-lucide="log-out" class="w-4 h-4"></i>
-                        Cerrar sesión
-                    </button>
+                    <div class="flex flex-wrap items-center gap-2">
+                        <button id="change-password-btn" class="inline-flex items-center gap-2 rounded-lg border border-blue-200 bg-blue-50 px-4 py-2 text-sm font-medium text-blue-600 transition hover:bg-blue-100">
+                            <i data-lucide="key-round" class="w-4 h-4"></i>
+                            Cambiar contraseña
+                        </button>
+                        <button id="logout-btn-modal" class="inline-flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 px-4 py-2 text-sm font-medium text-red-600 transition hover:bg-red-100">
+                            <i data-lucide="log-out" class="w-4 h-4"></i>
+                            Cerrar sesión
+                        </button>
+                    </div>
                 </div>
 
             </div>
@@ -183,32 +238,40 @@ async function openUserMenu() {
         }
 
         const logoutButton = document.getElementById('logout-btn-modal');
-        if (!logoutButton) return;
+        if (logoutButton) {
+            logoutButton.addEventListener('click', async () => {
+                try {
+                    const confirmed = await ui.showConfirmModal('¿Estás seguro de cerrar sesión?', {
+                        title: 'Confirmar cierre de sesión',
+                        confirmText: 'Cerrar sesión',
+                        cancelText: 'Cancelar',
+                        type: 'warning'
+                    });
 
-        logoutButton.addEventListener('click', async () => {
-            try {
-                const confirmed = await ui.showConfirmModal('¿Estás seguro de cerrar sesión?', {
-                    title: 'Confirmar cierre de sesión',
-                    confirmText: 'Cerrar sesión',
-                    cancelText: 'Cancelar',
-                    type: 'warning'
-                });
+                    if (!confirmed) return;
 
-                if (!confirmed) return;
+                    ui.hideModal(modalId);
+                    await signOut();
+                    ui.showToast('Sesión cerrada correctamente', 'success');
 
+                    setTimeout(() => {
+                        navigateTo('/login', {}, true);
+                        window.location.reload();
+                    }, 300);
+                } catch (error) {
+                    console.error('Error al cerrar sesión:', error);
+                    ui.showToast('Error al cerrar sesión', 'error');
+                }
+            });
+        }
+
+        const changePasswordButton = document.getElementById('change-password-btn');
+        if (changePasswordButton) {
+            changePasswordButton.addEventListener('click', () => {
                 ui.hideModal(modalId);
-                await signOut();
-                ui.showToast('Sesión cerrada correctamente', 'success');
-
-                setTimeout(() => {
-                    navigateTo('/login', {}, true);
-                    window.location.reload();
-                }, 300);
-            } catch (error) {
-                console.error('Error al cerrar sesión:', error);
-                ui.showToast('Error al cerrar sesión', 'error');
-            }
-        });
+                openChangePasswordModal();
+            });
+        }
     }, 100);
 }
 
@@ -217,6 +280,167 @@ function setupUserMenu() {
     if (!button) return;
 
     button.addEventListener('click', openUserMenu);
+}
+
+function openChangePasswordModal() {
+    let isSubmitting = false;
+
+    const modalId = ui.showModal({
+        title: 'Cambiar contraseña',
+        content: `
+            <form id="change-password-form" class="space-y-4">
+                <div>
+                    <label for="current-password" class="block text-sm font-medium text-gray-700">Contraseña actual</label>
+                    <input id="current-password" type="password" autocomplete="current-password" class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-aifa-blue focus:outline-none focus:ring-1 focus:ring-aifa-blue" required>
+                </div>
+                <div class="grid gap-4 sm:grid-cols-2">
+                    <div>
+                        <label for="new-password" class="block text-sm font-medium text-gray-700">Nueva contraseña</label>
+                        <input id="new-password" type="password" autocomplete="new-password" class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-aifa-blue focus:outline-none focus:ring-1 focus:ring-aifa-blue" required>
+                    </div>
+                    <div>
+                        <label for="confirm-password" class="block text-sm font-medium text-gray-700">Confirmar nueva contraseña</label>
+                        <input id="confirm-password" type="password" autocomplete="new-password" class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-aifa-blue focus:outline-none focus:ring-1 focus:ring-aifa-blue" required>
+                    </div>
+                </div>
+                <div id="change-password-error" class="hidden rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-600"></div>
+                <p class="text-xs text-gray-500">La nueva contraseña debe tener al menos 8 caracteres.</p>
+            </form>
+        `,
+        actions: [
+            {
+                text: 'Cancelar',
+                handler: () => true
+            },
+            {
+                text: 'Actualizar contraseña',
+                primary: true,
+                handler: async () => {
+                    if (isSubmitting) {
+                        return false;
+                    }
+
+                    const errorContainer = document.getElementById('change-password-error');
+                    const currentInput = document.getElementById('current-password');
+                    const newInput = document.getElementById('new-password');
+                    const confirmInput = document.getElementById('confirm-password');
+                    const submitButton = document.getElementById('modal-action-1');
+
+                    const clearError = () => {
+                        if (errorContainer) {
+                            errorContainer.textContent = '';
+                            errorContainer.classList.add('hidden');
+                        }
+                    };
+
+                    const showError = (message) => {
+                        if (errorContainer) {
+                            errorContainer.textContent = message;
+                            errorContainer.classList.remove('hidden');
+                        }
+                    };
+
+                    const resetFieldState = (field) => {
+                        if (field) {
+                            field.classList.remove('border-red-500', 'bg-red-50');
+                        }
+                    };
+
+                    const markFieldError = (field) => {
+                        if (field) {
+                            field.classList.add('border-red-500', 'bg-red-50');
+                        }
+                    };
+
+                    clearError();
+                    [currentInput, newInput, confirmInput].forEach(resetFieldState);
+
+                    const currentPassword = currentInput?.value?.trim() || '';
+                    const newPassword = newInput?.value?.trim() || '';
+                    const confirmPassword = confirmInput?.value?.trim() || '';
+
+                    if (!currentPassword || !newPassword || !confirmPassword) {
+                        showError('Completa todos los campos para continuar.');
+                        [currentInput, newInput, confirmInput].forEach(markFieldError);
+                        return false;
+                    }
+
+                    if (newPassword.length < 8) {
+                        showError('La nueva contraseña debe tener al menos 8 caracteres.');
+                        markFieldError(newInput);
+                        markFieldError(confirmInput);
+                        return false;
+                    }
+
+                    if (newPassword !== confirmPassword) {
+                        showError('Las contraseñas nuevas no coinciden.');
+                        markFieldError(newInput);
+                        markFieldError(confirmInput);
+                        return false;
+                    }
+
+                    if (currentPassword === newPassword) {
+                        showError('La nueva contraseña debe ser diferente a la actual.');
+                        markFieldError(newInput);
+                        return false;
+                    }
+
+                    if (submitButton) {
+                        submitButton.disabled = true;
+                        submitButton.dataset.originalText = submitButton.dataset.originalText || submitButton.textContent;
+                        submitButton.textContent = 'Actualizando...';
+                    }
+
+                    isSubmitting = true;
+
+                    try {
+                        await changePassword(currentPassword, newPassword);
+                        ui.showToast('Contraseña actualizada correctamente', 'success');
+                        clearError();
+                        return true;
+                    } catch (error) {
+                        console.error('Error al cambiar contraseña:', error);
+                        const message = error?.message || 'No fue posible actualizar la contraseña.';
+                        showError(message);
+
+                        if (error?.code === 'INVALID_CREDENTIALS') {
+                            markFieldError(currentInput);
+                            currentInput?.focus();
+                        }
+
+                        ui.showToast(message, 'error');
+                        return false;
+                    } finally {
+                        isSubmitting = false;
+                        if (submitButton) {
+                            submitButton.disabled = false;
+                            submitButton.textContent = submitButton.dataset.originalText || 'Actualizar contraseña';
+                        }
+                    }
+                }
+            }
+        ]
+    });
+
+    setTimeout(() => {
+        if (window.lucide) {
+            window.lucide.createIcons();
+        }
+
+        const form = document.getElementById('change-password-form');
+        if (form) {
+            form.addEventListener('submit', event => {
+                event.preventDefault();
+                const submitButton = document.getElementById('modal-action-1');
+                submitButton?.click();
+            });
+        }
+
+        const currentInput = document.getElementById('current-password');
+        currentInput?.focus();
+    }, 100);
+
+    return modalId;
 }
 
 // =====================================================
@@ -229,6 +453,7 @@ async function bootstrap() {
         setupGlobalErrorHandlers();
         setupNavigation();
         setupUserMenu();
+        updateNavigationVisibility();
 
         if (window.lucide) {
             window.lucide.createIcons();

--- a/js/lib/supa.js
+++ b/js/lib/supa.js
@@ -613,20 +613,20 @@ export async function getCurrentProfile() {
 export async function signInWithPassword(email, password) {
     try {
         if (DEBUG.enabled) console.log('🔐 Intentando login:', email);
-        
+
         const { data, error } = await supabase.auth.signInWithPassword({
             email: email.trim(),
             password: password
         });
-        
+
         if (error) {
             console.error('❌ Error en login:', error);
             throw new SupabaseError(error.message, error.name);
         }
-        
+
         appState.session = data.session;
         appState.user = data.user;
-        
+
         // Cargar perfil del usuario
         //appState.profile = await getCurrentProfile();
         try {
@@ -639,13 +639,89 @@ export async function signInWithPassword(email, password) {
                 rol_principal: 'ADMIN'
             };
         }
-        
+
         if (DEBUG.enabled) console.log('✅ Login exitoso:', data.user.email);
-        
+
         return { data };
     } catch (error) {
         handleError(error, 'Error al iniciar sesión');
         throw error;
+    }
+}
+
+/**
+ * Cambiar la contraseña del usuario autenticado
+ */
+export async function changePassword(currentPassword, newPassword) {
+    if (!appState.user?.email) {
+        throw new SupabaseError('No hay una sesión activa. Inicia sesión nuevamente.');
+    }
+
+    try {
+        const { data: reauthData, error: reauthError } = await supabase.auth.signInWithPassword({
+            email: appState.user.email,
+            password: currentPassword
+        });
+
+        if (reauthError) {
+            const message = (reauthError.message || '').toLowerCase();
+            if (message.includes('invalid') && message.includes('credentials')) {
+                throw new SupabaseError(
+                    'La contraseña actual es incorrecta.',
+                    'INVALID_CREDENTIALS',
+                    reauthError
+                );
+            }
+
+            throw reauthError;
+        }
+
+        if (reauthData?.session) {
+            appState.session = reauthData.session;
+        }
+
+        if (reauthData?.user) {
+            appState.user = reauthData.user;
+        }
+
+        const { data, error } = await supabase.auth.updateUser({
+            password: newPassword
+        });
+
+        if (error) {
+            throw error;
+        }
+
+        if (data?.user) {
+            appState.user = data.user;
+        }
+
+        // Refrescar la sesión para evitar estados inconsistentes tras actualizar credenciales.
+        try {
+            const { data: refreshedSession, error: refreshError } = await supabase.auth.getSession();
+            if (!refreshError && refreshedSession?.session) {
+                appState.session = refreshedSession.session;
+            }
+        } catch (refreshError) {
+            if (DEBUG.enabled) {
+                console.warn('⚠️ No se pudo refrescar la sesión después del cambio de contraseña:', refreshError);
+            }
+        }
+
+        if (DEBUG.enabled) {
+            console.log('✅ Contraseña actualizada para', appState.user?.email);
+        }
+
+        notifyAuthListeners('PASSWORD_CHANGED', appState.session);
+
+        return true;
+    } catch (error) {
+        if (error instanceof SupabaseError) {
+            throw error;
+        }
+
+        const message = handleError(error, 'Error al actualizar la contraseña');
+        throw new SupabaseError(message, error?.code || error?.name, error);
     }
 }
 


### PR DESCRIPTION
## Summary
- Ocultar la barra de navegación cuando no hay sesión activa y limitar los accesos del menú para perfiles de director.
- Mostrar el nombre de la persona autenticada en el botón de cuenta y ajustar el texto "Aeropuerto Internacional Felipe Ángeles".
- Añadir un flujo de cambio de contraseña con validaciones, soporte desde Supabase y manejo de errores para reintentos.

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5a6e6edd8832e9ee72f0cb4914ddd