### PR TITLE
Adjust header layout and separate password change modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,11 +110,11 @@
   <!-- Header -->
   <header class="bg-white shadow-sm border-b">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-      <div class="flex justify-between items-center h-16">
+      <div class="flex justify-between items-center py-4">
         <!-- Logo y título -->
         <div class="flex items-center space-x-4">
           <div class="flex-shrink-0">
-            <img src="assets/AIFA_Logo.png" alt="Logo AIFA" class="h-14 w-auto sm:h-16" 
+            <img src="assets/AIFA_Logo.png" alt="Logo AIFA" class="h-16 w-auto sm:h-20"
                  onerror="this.src='data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDgiIGhlaWdodD0iNDgiIHZpZXdCb3g9IjAgMCA0OCA0OCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjQ4IiBoZWlnaHQ9IjQ4IiByeD0iOCIgZmlsbD0iIzFFNDBBRiIvPgo8cGF0aCBkPSJNMTIgMzZIMzZWMTJIMTJWMzZaIiBzdHJva2U9IndoaXRlIiBzdHJva2Utd2lkdGg9IjIiLz4KPHA+dGggZD0iTTE4IDI0TDI0IDE4TDMwIDI0IiBzdHJva2U9IndoaXRlIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIvPgo8L3N2Zz4K';">
           </div>
           <div>
@@ -126,7 +126,7 @@
         </div>
         
         <!-- Navegación -->
-        <nav class="hidden sm:flex items-center space-x-4">
+        <nav id="main-nav" hidden class="flex flex-wrap items-center gap-2 sm:gap-4" aria-hidden="true">
           <button id="nav-home" class="nav-button flex items-center gap-2 px-3 py-2 rounded-lg text-gray-600 bg-white hover:bg-gray-100">
             <i data-lucide="home" class="w-4 h-4"></i><span>Inicio</span>
           </button>
@@ -146,13 +146,13 @@
         </nav>
         
         <!-- Usuario -->
-        <div class="flex items-center space-x-3">
-          <div id="user-info" class="hidden text-right">
-            <div class="text-sm font-medium text-gray-900" id="user-name">Usuario</div>
-            <div class="text-xs text-gray-600" id="user-role">Rol</div>
-          </div>
-          <button id="user-menu-button" class="flex items-center gap-2 px-3 py-2 rounded-lg text-gray-600 bg-white hover:bg-gray-100">
-            <i data-lucide="user" class="w-4 h-4"></i><span class="hidden sm:inline">Cuenta</span>
+        <div class="flex items-center">
+          <button id="user-menu-button" class="flex items-center gap-3 px-3 py-2 rounded-lg text-gray-600 bg-white hover:bg-gray-100 transition">
+            <i data-lucide="user" class="w-4 h-4 flex-shrink-0"></i>
+            <div class="flex flex-col items-start leading-tight text-left">
+              <span id="user-name" class="text-sm font-medium text-gray-900">Usuario</span>
+              <span id="user-role" class="text-xs text-gray-500 hidden">Rol</span>
+            </div>
           </button>
         </div>
       </div>

--- a/js/app/bootstrap.js
+++ b/js/app/bootstrap.js
@@ -3,11 +3,11 @@
 // Inicializa configuración, router, navegación y sesión.
 // =====================================================
 
-import { DEBUG } from '../config.js';
+import { DEBUG, VALIDATION } from '../config.js';
 import { routes, getNavigationBindings } from './routes.js';
 import { initRouter, navigateTo, goBack, reloadCurrentRoute, parseCurrentRoute, getDefaultRouteForUser } from '../lib/router.js';
 import * as ui from '../lib/ui.js';
-import { initSupabase, appState, getCurrentProfile, onAuthStateChange, isAuthenticated, signOut } from '../lib/supa.js';
+import { initSupabase, appState, getCurrentProfile, onAuthStateChange, isAuthenticated, signOut, changePassword } from '../lib/supa.js';
 
 // =====================================================
 // UTILIDADES
@@ -23,6 +23,16 @@ const ROLE_NAMES = {
 
 function getRoleLabel(role) {
     return ROLE_NAMES[role] || role || 'Sin rol';
+}
+
+function escapeHTML(value) {
+    if (value === null || value === undefined) return '';
+    return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
 }
 
 function exposeGlobals() {
@@ -66,33 +76,54 @@ function setupNavigation() {
 }
 
 function updateUserHeader() {
-    const userInfo = document.getElementById('user-info');
     const userName = document.getElementById('user-name');
     const userRole = document.getElementById('user-role');
+    const userMenuButton = document.getElementById('user-menu-button');
 
     const { user, profile } = appState;
+    const hasUser = Boolean(user && profile);
 
-    if (user && profile) {
-        if (userInfo) {
-            userInfo.classList.remove('hidden');
-        }
-        if (userName) {
-            userName.textContent = profile.nombre_completo || user.email || 'Usuario';
-        }
-        if (userRole) {
-            userRole.textContent = getRoleLabel(profile.rol_principal);
-        }
-    } else {
-        if (userInfo) {
-            userInfo.classList.add('hidden');
-        }
-        if (userName) {
-            userName.textContent = 'Usuario';
-        }
-        if (userRole) {
+    const displayName = hasUser
+        ? (profile?.nombre_completo?.trim() || user?.email || 'Usuario')
+        : 'Usuario';
+
+    const roleLabel = hasUser && profile?.rol_principal
+        ? getRoleLabel(profile.rol_principal)
+        : '';
+
+    if (userName) {
+        userName.textContent = displayName;
+    }
+
+    if (userRole) {
+        if (roleLabel) {
+            userRole.textContent = roleLabel;
+            userRole.classList.remove('hidden');
+        } else {
             userRole.textContent = '';
+            if (!userRole.classList.contains('hidden')) {
+                userRole.classList.add('hidden');
+            }
         }
     }
+
+    if (userMenuButton) {
+        userMenuButton.setAttribute(
+            'aria-label',
+            hasUser ? `Menú de usuario ${displayName}` : 'Menú de usuario'
+        );
+        userMenuButton.disabled = false;
+        userMenuButton.classList.remove('btn-disabled');
+    }
+}
+
+function updateNavigationVisibility() {
+    const navigation = document.getElementById('main-nav');
+    if (!navigation) return;
+
+    const shouldShowNav = isAuthenticated();
+    navigation.hidden = !shouldShowNav;
+    navigation.setAttribute('aria-hidden', shouldShowNav ? 'false' : 'true');
 }
 
 async function openUserMenu() {
@@ -102,15 +133,6 @@ async function openUserMenu() {
     }
 
     const profile = appState.profile || await getCurrentProfile();
-    const escapeHTML = (value) => {
-        if (value === null || value === undefined) return '';
-        return String(value)
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;')
-            .replace(/'/g, '&#39;');
-    };
 
     const displayName = escapeHTML(
         profile?.nombre_completo?.trim() ||
@@ -158,6 +180,25 @@ async function openUserMenu() {
                 <div class="grid gap-4">
                     ${infoFields.map(renderInfoField).join('')}
                 </div>
+                <section class="space-y-4 border-t border-gray-100 pt-4">
+                    <div class="space-y-1">
+                        <h4 class="flex items-center gap-2 text-sm font-semibold text-gray-900">
+                            <i data-lucide="shield" class="h-4 w-4"></i>
+                            Seguridad
+                        </h4>
+                        <p class="text-xs leading-snug text-gray-500">
+                            Actualiza tu contraseña para mantener tu cuenta protegida.
+                        </p>
+                    </div>
+                    <button
+                        id="open-change-password"
+                        type="button"
+                        class="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-aifa-blue/30 bg-white px-4 py-2 text-sm font-medium text-aifa-blue transition hover:bg-aifa-blue hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-aifa-blue sm:w-auto"
+                    >
+                        <i data-lucide="key-round" class="h-4 w-4"></i>
+                        Cambiar contraseña
+                    </button>
+                </section>
                 <div class="flex items-center justify-between gap-3 border-t border-gray-100 pt-4">
                     <p class="text-xs leading-snug text-gray-500">Gestiona tu sesión desde esta ventana.</p>
                     <button id="logout-btn-modal" class="inline-flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 px-4 py-2 text-sm font-medium text-red-600 transition hover:bg-red-100">
@@ -172,7 +213,6 @@ async function openUserMenu() {
             {
                 text: 'Cerrar',
                 handler: () => true
-
             }
         ]
     });
@@ -183,34 +223,280 @@ async function openUserMenu() {
         }
 
         const logoutButton = document.getElementById('logout-btn-modal');
-        if (!logoutButton) return;
+        if (logoutButton) {
+            logoutButton.addEventListener('click', async () => {
+                try {
+                    const confirmed = await ui.showConfirmModal('¿Estás seguro de cerrar sesión?', {
+                        title: 'Confirmar cierre de sesión',
+                        confirmText: 'Cerrar sesión',
+                        cancelText: 'Cancelar',
+                        type: 'warning'
+                    });
 
-        logoutButton.addEventListener('click', async () => {
-            try {
-                const confirmed = await ui.showConfirmModal('¿Estás seguro de cerrar sesión?', {
-                    title: 'Confirmar cierre de sesión',
-                    confirmText: 'Cerrar sesión',
-                    cancelText: 'Cancelar',
-                    type: 'warning'
-                });
+                    if (!confirmed) return;
 
-                if (!confirmed) return;
+                    ui.hideModal(modalId);
+                    await signOut();
+                    ui.showToast('Sesión cerrada correctamente', 'success');
 
+                    setTimeout(() => {
+                        navigateTo('/login', {}, true);
+                        window.location.reload();
+                    }, 300);
+                } catch (error) {
+                    console.error('Error al cerrar sesión:', error);
+                    ui.showToast('Error al cerrar sesión', 'error');
+                }
+            });
+        }
+
+        const changePasswordTrigger = document.getElementById('open-change-password');
+        if (changePasswordTrigger) {
+            changePasswordTrigger.addEventListener('click', () => {
                 ui.hideModal(modalId);
-                await signOut();
-                ui.showToast('Sesión cerrada correctamente', 'success');
 
                 setTimeout(() => {
-                    navigateTo('/login', {}, true);
-                    window.location.reload();
-                }, 300);
-            } catch (error) {
-                console.error('Error al cerrar sesión:', error);
-                ui.showToast('Error al cerrar sesión', 'error');
-            }
-        });
+                    openChangePasswordModal({
+                        onCancel: () => openUserMenu(),
+                        onSuccess: () => openUserMenu()
+                    });
+                }, 120);
+            });
+        }
     }, 100);
 }
+
+
+function openChangePasswordModal({ onSuccess = null, onCancel = null } = {}) {
+    const passwordRules = VALIDATION?.password || {};
+    const passwordMinLength = passwordRules?.minLength || 8;
+    const passwordMaxLengthAttr = passwordRules?.maxLength ? ` maxlength="${passwordRules.maxLength}"` : '';
+    const passwordRequirementsMessage = escapeHTML(
+        passwordRules?.message || 'La contraseña debe cumplir con los requisitos de seguridad.'
+    );
+
+    let wasSuccessful = false;
+
+    const modalId = ui.showModal({
+        title: 'Cambiar contraseña',
+        content: `
+            <form id="change-password-form" class="space-y-3" novalidate>
+                <div>
+                    <label for="current-password" class="mb-1 block text-xs font-semibold uppercase tracking-wide text-gray-500">Contraseña actual</label>
+                    <input
+                        id="current-password"
+                        name="currentPassword"
+                        type="password"
+                        autocomplete="current-password"
+                        class="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-700 shadow-sm focus:border-aifa-blue focus:outline-none focus:ring-2 focus:ring-aifa-blue/20"
+                        required
+                    />
+                </div>
+                <div>
+                    <label for="new-password" class="mb-1 block text-xs font-semibold uppercase tracking-wide text-gray-500">Nueva contraseña</label>
+                    <input
+                        id="new-password"
+                        name="newPassword"
+                        type="password"
+                        autocomplete="new-password"
+                        minlength="${passwordMinLength}"${passwordMaxLengthAttr}
+                        class="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-700 shadow-sm focus:border-aifa-blue focus:outline-none focus:ring-2 focus:ring-aifa-blue/20"
+                        required
+                    />
+                </div>
+                <div>
+                    <label for="confirm-password" class="mb-1 block text-xs font-semibold uppercase tracking-wide text-gray-500">Confirmar nueva contraseña</label>
+                    <input
+                        id="confirm-password"
+                        name="confirmPassword"
+                        type="password"
+                        autocomplete="new-password"
+                        minlength="${passwordMinLength}"${passwordMaxLengthAttr}
+                        class="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-700 shadow-sm focus:border-aifa-blue focus:outline-none focus:ring-2 focus:ring-aifa-blue/20"
+                        required
+                    />
+                </div>
+                <p id="change-password-feedback" class="text-xs hidden"></p>
+                <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <p class="text-xs leading-snug text-gray-500 sm:max-w-xs">
+                        ${passwordRequirementsMessage}
+                    </p>
+                    <button
+                        id="change-password-submit"
+                        type="submit"
+                        class="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-aifa-blue px-4 py-2 text-sm font-medium text-white transition hover:bg-aifa-dark focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-aifa-blue sm:w-auto"
+                    >
+                        <span id="change-password-submit-content" class="inline-flex items-center gap-2">
+                            <i data-lucide="key-round" class="h-4 w-4"></i>
+                            Actualizar contraseña
+                        </span>
+                        <span id="change-password-submit-loading" class="hidden items-center gap-2">
+                            <i data-lucide="loader-2" class="h-4 w-4 animate-spin"></i>
+                            Guardando...
+                        </span>
+                    </button>
+                </div>
+            </form>
+        `,
+        actions: [
+            {
+                text: 'Cancelar',
+                handler: () => true
+            }
+        ],
+        onClose: () => {
+            if (!wasSuccessful && typeof onCancel === 'function') {
+                setTimeout(() => onCancel(), 0);
+            }
+        }
+    });
+
+    setTimeout(() => {
+        if (window.lucide) {
+            window.lucide.createIcons();
+        }
+
+        const changePasswordForm = document.getElementById('change-password-form');
+        const changePasswordButton = document.getElementById('change-password-submit');
+        const changePasswordFeedback = document.getElementById('change-password-feedback');
+        const changePasswordButtonContent = document.getElementById('change-password-submit-content');
+        const changePasswordButtonLoading = document.getElementById('change-password-submit-loading');
+        const currentPasswordInput = document.getElementById('current-password');
+        const newPasswordInput = document.getElementById('new-password');
+        const confirmPasswordInput = document.getElementById('confirm-password');
+
+        if (
+            changePasswordForm &&
+            changePasswordButton &&
+            changePasswordFeedback &&
+            changePasswordButtonContent &&
+            changePasswordButtonLoading &&
+            currentPasswordInput &&
+            newPasswordInput &&
+            confirmPasswordInput
+        ) {
+            const inputs = [currentPasswordInput, newPasswordInput, confirmPasswordInput];
+
+            const clearFeedback = () => {
+                changePasswordFeedback.textContent = '';
+                changePasswordFeedback.classList.add('hidden');
+                changePasswordFeedback.classList.remove('text-red-600', 'text-green-600');
+            };
+
+            const showFeedback = (message, type = 'error') => {
+                changePasswordFeedback.textContent = message;
+                changePasswordFeedback.classList.remove('hidden');
+                changePasswordFeedback.classList.remove('text-red-600', 'text-green-600');
+                changePasswordFeedback.classList.add(type === 'success' ? 'text-green-600' : 'text-red-600');
+            };
+
+            const toggleButtonLoading = (isLoading) => {
+                changePasswordButton.disabled = isLoading;
+                changePasswordButton.classList.toggle('btn-disabled', isLoading);
+                if (isLoading) {
+                    changePasswordButtonContent.classList.add('hidden');
+                    changePasswordButtonLoading.classList.remove('hidden');
+                } else {
+                    changePasswordButtonContent.classList.remove('hidden');
+                    changePasswordButtonLoading.classList.add('hidden');
+                }
+            };
+
+            inputs.forEach(input => {
+                input.addEventListener('input', () => {
+                    input.classList.remove('input-error');
+                    if (!changePasswordFeedback.classList.contains('hidden')) {
+                        clearFeedback();
+                    }
+                });
+            });
+
+            changePasswordForm.addEventListener('submit', async (event) => {
+                event.preventDefault();
+
+                inputs.forEach(input => input.classList.remove('input-error'));
+                clearFeedback();
+
+                const currentPassword = currentPasswordInput.value;
+                const newPassword = newPasswordInput.value;
+                const confirmPassword = confirmPasswordInput.value;
+
+                if (!currentPassword.trim()) {
+                    currentPasswordInput.classList.add('input-error');
+                    currentPasswordInput.focus();
+                    showFeedback('Ingresa tu contraseña actual.', 'error');
+                    return;
+                }
+
+                if (!newPassword.trim()) {
+                    newPasswordInput.classList.add('input-error');
+                    newPasswordInput.focus();
+                    showFeedback('Ingresa una nueva contraseña.', 'error');
+                    return;
+                }
+
+                if (passwordRules.minLength && newPassword.length < passwordRules.minLength) {
+                    newPasswordInput.classList.add('input-error');
+                    newPasswordInput.focus();
+                    showFeedback(passwordRules.message || `La contraseña debe tener al menos ${passwordRules.minLength} caracteres.`, 'error');
+                    return;
+                }
+
+                if (passwordRules.maxLength && newPassword.length > passwordRules.maxLength) {
+                    newPasswordInput.classList.add('input-error');
+                    newPasswordInput.focus();
+                    showFeedback(`La contraseña no puede exceder ${passwordRules.maxLength} caracteres.`, 'error');
+                    return;
+                }
+
+                if (passwordRules.pattern instanceof RegExp && !passwordRules.pattern.test(newPassword)) {
+                    newPasswordInput.classList.add('input-error');
+                    newPasswordInput.focus();
+                    showFeedback(passwordRules.message || 'La contraseña no cumple con los requisitos de seguridad.', 'error');
+                    return;
+                }
+
+                if (newPassword === currentPassword) {
+                    newPasswordInput.classList.add('input-error');
+                    newPasswordInput.focus();
+                    showFeedback('La nueva contraseña debe ser diferente a la actual.', 'error');
+                    return;
+                }
+
+                if (newPassword !== confirmPassword) {
+                    confirmPasswordInput.classList.add('input-error');
+                    confirmPasswordInput.focus();
+                    showFeedback('La confirmación no coincide con la nueva contraseña.', 'error');
+                    return;
+                }
+
+                try {
+                    toggleButtonLoading(true);
+                    await changePassword(currentPassword, newPassword);
+                    showFeedback('Contraseña actualizada correctamente.', 'success');
+                    changePasswordForm.reset();
+                    inputs.forEach(input => input.classList.remove('input-error'));
+                    ui.showToast('Contraseña actualizada correctamente', 'success');
+
+                    wasSuccessful = true;
+                    setTimeout(() => {
+                        ui.hideModal(modalId);
+                        if (typeof onSuccess === 'function') {
+                            onSuccess();
+                        }
+                    }, 600);
+                } catch (error) {
+                    console.error('Error al cambiar contraseña:', error);
+                    const message = error?.message || 'No se pudo actualizar la contraseña.';
+                    showFeedback(message, 'error');
+                } finally {
+                    toggleButtonLoading(false);
+                }
+            });
+        }
+    }, 100);
+}
+
 
 function setupUserMenu() {
     const button = document.getElementById('user-menu-button');
@@ -236,9 +522,11 @@ async function bootstrap() {
 
         await initSupabase();
         updateUserHeader();
+        updateNavigationVisibility();
 
         onAuthStateChange(() => {
             updateUserHeader();
+            updateNavigationVisibility();
         });
 
         if (!window.location.hash) {

--- a/js/lib/supa.js
+++ b/js/lib/supa.js
@@ -655,23 +655,76 @@ export async function signInWithPassword(email, password) {
 export async function signOut() {
     try {
         const { error } = await supabase.auth.signOut();
-        
+
         if (error) {
             console.error('❌ Error al cerrar sesión:', error);
             throw error;
         }
-        
+
         // Limpiar estado
         appState.user = null;
         appState.profile = null;
         appState.session = null;
-        
+
         if (DEBUG.enabled) console.log('✅ Sesión cerrada correctamente');
-        
+
         return true;
     } catch (error) {
         handleError(error, 'Error al cerrar sesión');
         throw error;
+    }
+}
+
+/**
+ * Cambiar contraseña del usuario autenticado
+ */
+export async function changePassword(currentPassword, newPassword) {
+    if (!appState.user?.email) {
+        throw new SupabaseError('No hay una sesión activa.');
+    }
+
+    const email = appState.user.email;
+
+    try {
+        const { data: verificationData, error: verificationError } = await supabase.auth.signInWithPassword({
+            email,
+            password: currentPassword
+        });
+
+        if (verificationError) {
+            throw new SupabaseError('La contraseña actual es incorrecta', verificationError.code || verificationError.name, verificationError);
+        }
+
+        if (verificationData?.session) {
+            appState.session = verificationData.session;
+        }
+
+        if (verificationData?.user) {
+            appState.user = verificationData.user;
+        }
+
+        const { data, error } = await supabase.auth.updateUser({
+            password: newPassword
+        });
+
+        if (error) {
+            throw error;
+        }
+
+        if (data?.user) {
+            appState.user = data.user;
+        }
+
+        notifyAuthListeners('PASSWORD_UPDATED', appState.session);
+
+        return true;
+    } catch (error) {
+        if (error instanceof SupabaseError) {
+            throw error;
+        }
+
+        const message = handleError(error, 'Error al cambiar contraseña');
+        throw new SupabaseError(message, error?.code || error?.name, error);
     }
 }
 


### PR DESCRIPTION
## Summary
- enlarge the header layout so the AIFA logo and title render without clipping while keeping the menu responsive
- hide the top navigation buttons until a session is authenticated and reuse them after login
- move the change password flow into its own modal launched from the account dialog, keeping the existing validation and feedback

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6a5ade568832eb9abb2b9b1a7b8a2