### PR TITLE
Fix duplicate changePassword function in Supabase helper

### DIFF
--- a/js/app/bootstrap.js
+++ b/js/app/bootstrap.js
@@ -119,6 +119,7 @@ function syncNavigationVisibility() {
 }
 
 function updateUserHeader() {
+    const userInfo = document.getElementById('user-info');
     const userName = document.getElementById('user-name');
     const userRole = document.getElementById('user-role');
     const userMenuLabel = document.getElementById('user-menu-label');

--- a/js/lib/supa.js
+++ b/js/lib/supa.js
@@ -858,7 +858,7 @@ export async function changePassword(currentPassword, newPassword) {
             console.log('✅ Contraseña actualizada para', appState.user?.email);
         }
 
-        notifyAuthListeners('PASSWORD_CHANGED', appState.session);
+        notifyAuthListeners('PASSWORD_UPDATED', appState.session);
 
         return true;
     } catch (error) {
@@ -894,59 +894,6 @@ export async function signOut() {
     } catch (error) {
         handleError(error, 'Error al cerrar sesión');
         throw error;
-    }
-}
-
-/**
- * Cambiar contraseña del usuario autenticado
- */
-export async function changePassword(currentPassword, newPassword) {
-    if (!appState.user?.email) {
-        throw new SupabaseError('No hay una sesión activa.');
-    }
-
-    const email = appState.user.email;
-
-    try {
-        const { data: verificationData, error: verificationError } = await supabase.auth.signInWithPassword({
-            email,
-            password: currentPassword
-        });
-
-        if (verificationError) {
-            throw new SupabaseError('La contraseña actual es incorrecta', verificationError.code || verificationError.name, verificationError);
-        }
-
-        if (verificationData?.session) {
-            appState.session = verificationData.session;
-        }
-
-        if (verificationData?.user) {
-            appState.user = verificationData.user;
-        }
-
-        const { data, error } = await supabase.auth.updateUser({
-            password: newPassword
-        });
-
-        if (error) {
-            throw error;
-        }
-
-        if (data?.user) {
-            appState.user = data.user;
-        }
-
-        notifyAuthListeners('PASSWORD_UPDATED', appState.session);
-
-        return true;
-    } catch (error) {
-        if (error instanceof SupabaseError) {
-            throw error;
-        }
-
-        const message = handleError(error, 'Error al cambiar contraseña');
-        throw new SupabaseError(message, error?.code || error?.name, error);
     }
 }
 


### PR DESCRIPTION
## Summary
- remove the duplicated changePassword export in js/lib/supa.js
- keep the more robust implementation and standardize the auth notification event name
- ensure the user header looks up the user-info element before toggling visibility to avoid ReferenceError

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6c9c009ac832ea1154a60bcdf131a