### PR TITLE
Improve Supabase session handling during focus changes

### DIFF
--- a/js/app/bootstrap.js
+++ b/js/app/bootstrap.js
@@ -784,9 +784,10 @@ async function verifySessionOnReturn() {
             
             // Si pasó más de 30 minutos, verificar sesión
             if (Date.now() - sessionData.timestamp > 30 * 60 * 1000) {
-                await getCurrentSession();
-                
-                if (!appState.session) {
+                const previousSession = appState.session;
+                const session = await getCurrentSession({ allowRefresh: true });
+
+                if (!session && previousSession) {
                     console.warn('⚠️ Sesión expirada, redirigiendo al login');
                     navigateTo('/login', { message: 'Su sesión ha expirado', type: 'warning' }, true);
                     return;
@@ -830,25 +831,26 @@ function setupSessionMonitoring() {
     setInterval(async () => {
         if (appState.session && document.visibilityState === 'visible') {
             try {
-                const { data: { session }, error } = await supabase.auth.getSession();
-                
-                if (error || !session) {
+                const previousSession = appState.session;
+                const session = await getCurrentSession({ allowRefresh: true, silent: true });
+
+                if (!session && previousSession) {
                     console.warn('⚠️ Sesión perdida, redirigiendo al login');
-                    
+
                     // Limpiar estado
                     appState.session = null;
                     appState.user = null;
                     appState.profile = null;
-                    
+
                     // Limpiar intervals
                     if (window.autoRefreshInterval) clearInterval(window.autoRefreshInterval);
                     if (window.homeRefreshInterval) clearInterval(window.homeRefreshInterval);
                     if (window.areaRefreshInterval) clearInterval(window.areaRefreshInterval);
-                    
+
                     // Redirigir al login
-                    navigateTo('/login', { 
-                        message: 'Su sesión ha expirado. Por favor, inicie sesión nuevamente.', 
-                        type: 'warning' 
+                    navigateTo('/login', {
+                        message: 'Su sesión ha expirado. Por favor, inicie sesión nuevamente.',
+                        type: 'warning'
                     }, true);
                 }
             } catch (error) {
@@ -867,11 +869,12 @@ function setupSessionMonitoring() {
             // Al regresar a la pestaña, verificar sesión inmediatamente
             setTimeout(async () => {
                 try {
-                    await getCurrentSession();
-                    if (!appState.session) {
-                        navigateTo('/login', { 
-                            message: 'Su sesión ha expirado', 
-                            type: 'warning' 
+                    const previousSession = appState.session;
+                    const session = await getCurrentSession({ allowRefresh: true });
+                    if (!session && previousSession) {
+                        navigateTo('/login', {
+                            message: 'Su sesión ha expirado',
+                            type: 'warning'
                         }, true);
                     }
                 } catch (error) {
@@ -906,10 +909,11 @@ window.addEventListener('focus', () => {
     // Verificar sesión al recuperar foco
     setTimeout(async () => {
         try {
-            await getCurrentSession();
-            
+            const previousSession = appState.session;
+            const session = await getCurrentSession({ allowRefresh: true });
+
             // Verificar que appState tenga sesión
-            if (!appState.session) {
+            if (!session && previousSession) {
                 console.warn('⚠️ No hay sesión después de verificar');
                 navigateTo('/login', { message: 'Su sesión ha expirado', type: 'warning' }, true);
                 return;

--- a/js/lib/supa.js
+++ b/js/lib/supa.js
@@ -377,20 +377,61 @@ export async function callRPC(functionName, params = {}) {
 /**
  * Obtener sesión actual
  */
-export async function getCurrentSession() {
+async function refreshSession() {
     try {
-        const { data: { session }, error } = await supabase.auth.getSession();
-        
-        if (error) {
-            console.error('❌ Error al obtener sesión:', error);
+        const { data, error } = await supabase.auth.refreshSession();
+
+        if (error || !data?.session) {
+            if (DEBUG.enabled) {
+                console.warn('⚠️ No se pudo refrescar la sesión automáticamente:', error);
+            }
             return null;
         }
-        
-        appState.session = session;
-        return session;
+
+        return data.session;
+    } catch (error) {
+        console.error('❌ Error al refrescar la sesión:', error);
+        return null;
+    }
+}
+
+export async function getCurrentSession(options = {}) {
+    const { allowRefresh = false, silent = false } = options;
+
+    try {
+        const { data: { session }, error } = await supabase.auth.getSession();
+
+        if (error) {
+            console.error('❌ Error al obtener sesión:', error);
+            return appState.session;
+        }
+
+        if (session) {
+            appState.session = session;
+            appState.user = session.user;
+            return session;
+        }
+
+        if (allowRefresh && appState.session) {
+            const refreshedSession = await refreshSession();
+
+            if (refreshedSession) {
+                appState.session = refreshedSession;
+                appState.user = refreshedSession.user;
+                return refreshedSession;
+            }
+        }
+
+        if (!silent && appState.session) {
+            console.warn('⚠️ Sesión no disponible después de verificar');
+        }
+
+        appState.session = null;
+        appState.user = null;
+        return null;
     } catch (error) {
         console.error('❌ Error al verificar sesión:', error);
-        return null;
+        return appState.session;
     }
 }
 
@@ -1491,6 +1532,7 @@ export function escapeSearchText(text) {
 let isHandlingVisibilityChange = false;
 let visibilityChangeTimeout = null;
 let initializationPromise = null;
+let visibilityChangeHandler = null;
 
 async function setupSupabase() {
     try {
@@ -1523,7 +1565,7 @@ async function setupSupabase() {
         });
         
         // Verificar sesión inicial
-        await getCurrentSession();
+        await getCurrentSession({ allowRefresh: true, silent: true });
         if (appState.session) {
             appState.profile = await getCurrentProfile();
         }
@@ -1582,8 +1624,13 @@ initSupabase().catch(console.error);
  * Configurar handlers de visibilidad
  */
 function setupVisibilityHandlers() {
+    // Evitar duplicar handlers si la función se llama más de una vez
+    if (visibilityChangeHandler) {
+        document.removeEventListener('visibilitychange', visibilityChangeHandler);
+    }
+
     // Handler para cambios de visibilidad
-    const handleVisibilityChange = async () => {
+    visibilityChangeHandler = async () => {
         // Limpiar timeout anterior si existe
         if (visibilityChangeTimeout) {
             clearTimeout(visibilityChangeTimeout);
@@ -1608,33 +1655,25 @@ function setupVisibilityHandlers() {
                 if (isHandlingVisibilityChange) {
                     return;
                 }
-                
+
                 isHandlingVisibilityChange = true;
                 try {
-                    // Solo verificar la sesión, NO forzar un cambio de estado
-                    const { data: { session }, error } = await supabase.auth.getSession();
-                    
-                    if (error) {
-                        if (DEBUG.enabled) {
-                            console.warn('⚠️ Error al verificar sesión:', error);
-                        }
-                        return;
-                    }
-                    
+                    const previousSession = appState.session;
+                    const session = await getCurrentSession({ allowRefresh: true, silent: true });
+
                     if (session) {
                         // Solo actualizar si realmente cambió el token
-                        if (session.access_token !== appState.session?.access_token) {
+                        if (session.access_token !== previousSession?.access_token) {
                             appState.session = session;
                             appState.user = session.user;
-                            
+
                             if (DEBUG.enabled) {
                                 console.log('✅ Sesión actualizada silenciosamente');
                             }
                             // NO notificar a listeners para evitar re-renderizados
                         }
-                    } else if (appState.session) {
-                        // Solo si realmente se perdió la sesión
-                        appState.session = null;
+                    } else if (previousSession) {
+                        // Confirmar la pérdida real de sesión antes de notificar
                         appState.user = null;
                         appState.profile = null;
                         notifyAuthListeners('SIGNED_OUT', null);
@@ -1651,7 +1690,7 @@ function setupVisibilityHandlers() {
     };
     
     // Usar solo visibilitychange
-    document.addEventListener('visibilitychange', handleVisibilityChange);
+    document.addEventListener('visibilitychange', visibilityChangeHandler);
     
     if (DEBUG.enabled) {
         console.log('✅ Handlers de visibilidad configurados');
@@ -1673,7 +1712,7 @@ export function setupGlobalAutoRefresh() {
             // Solo hacer refresh si la ventana está visible y hay sesión
             if (document.visibilityState === 'visible' && appState.session) {
                 try {
-                    await getCurrentSession();
+                    await getCurrentSession({ allowRefresh: true, silent: true });
                 } catch (error) {
                     console.error('❌ Error en auto-refresh de sesión:', error);
                     clearInterval(window.autoRefreshInterval);
@@ -1703,11 +1742,17 @@ export function cleanupResources() {
     // Limpiar storage
     sessionStorage.removeItem('aifa-session-backup');
     sessionStorage.removeItem('aifa-last-activity');
-    
+
     // Limpiar event listeners de visibilidad si existen
-    document.removeEventListener('visibilitychange', handleVisibilityChange);
-    window.removeEventListener('beforeunload', handleBeforeUnload);
-    window.removeEventListener('pagehide', handlePageHide);
+    if (visibilityChangeTimeout) {
+        clearTimeout(visibilityChangeTimeout);
+        visibilityChangeTimeout = null;
+    }
+    isHandlingVisibilityChange = false;
+    if (visibilityChangeHandler) {
+        document.removeEventListener('visibilitychange', visibilityChangeHandler);
+        visibilityChangeHandler = null;
+    }
 }
 
 /**
@@ -1717,28 +1762,22 @@ function startTokenHealthCheck() {
     setInterval(async () => {
         if (appState.session && document.visibilityState === 'visible') {
             try {
-                const { data: { session }, error } = await supabase.auth.getSession();
-                
-                if (error || !session) {
+                const previousSession = appState.session;
+                const session = await getCurrentSession({ allowRefresh: true, silent: true });
+
+                if (!session && previousSession) {
                     console.warn('⚠️ Token expirado o inválido');
-                    
-                    // Intentar refrescar el token una vez
-                    const { data: refreshData, error: refreshError } = await supabase.auth.refreshSession();
-                    
-                    if (refreshError || !refreshData.session) {
-                        console.error('❌ No se pudo refrescar el token:', refreshError);
-                        
-                        // Limpiar estado y redirigir
-                        appState.session = null;
-                        appState.user = null;
-                        appState.profile = null;
-                        
-                        if (window.router?.navigateTo) {
-                            window.router.navigateTo('/login', { 
-                                message: 'Su sesión ha expirado. Por favor, inicie sesión nuevamente.', 
-                                type: 'warning' 
-                            }, true);
-                        }
+
+                    // Limpiar estado y redirigir
+                    appState.session = null;
+                    appState.user = null;
+                    appState.profile = null;
+
+                    if (window.router?.navigateTo) {
+                        window.router.navigateTo('/login', {
+                            message: 'Su sesión ha expirado. Por favor, inicie sesión nuevamente.',
+                            type: 'warning'
+                        }, true);
                     }
                 }
             } catch (error) {


### PR DESCRIPTION
## Summary
- add resilient session refresh logic that retries before dropping the user session
- harden visibility-change handling and cleanup to avoid stale listeners when focus changes
- update bootstrap monitoring to rely on the shared session helper and prevent false logouts on blur/focus

## Testing
- npm test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68da955dc944832e93091d2525aa7e78