### PR TITLE
Enhance visualization bar colors

### DIFF
--- a/js/views/visualizacion.js
+++ b/js/views/visualizacion.js
@@ -1430,7 +1430,7 @@ function prepareComparativeChartData() {
                     label: `${indicador.nombre} (${year})`,
                     data: data,
                     borderColor: colors[colorIndex % colors.length],
-                    backgroundColor: colors[colorIndex % colors.length] + '20',
+                    backgroundColor: colors[colorIndex % colors.length] + 'CC',
                     fill: false,
                     spanGaps: false,
                     tension: 0.1
@@ -1472,7 +1472,7 @@ function prepareDashboardChartData(indicadorId) {
             label: `${year}`,
             data: data,
             borderColor: colors[colorIndex % colors.length],
-            backgroundColor: colors[colorIndex % colors.length] + '20',
+            backgroundColor: colors[colorIndex % colors.length] + 'CC',
             fill: false,
             spanGaps: false,
             tension: 0.1
@@ -1530,7 +1530,7 @@ function prepareTrendsChartData() {
             label: indicador.nombre,
             data: normalizedData,
             borderColor: colors[colorIndex % colors.length],
-            backgroundColor: colors[colorIndex % colors.length] + '20',
+            backgroundColor: colors[colorIndex % colors.length] + 'CC',
             fill: false,
             tension: 0.1
         });


### PR DESCRIPTION
## Summary
- increase the opacity of visualization datasets so bar charts show bolder colors
- apply the richer color fill across comparative, dashboard, and trend datasets

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daa61ac240832e94c825ac6acb2a47