### PR TITLE
Fix Supabase queries to match new database schema

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -34,12 +34,12 @@ export function AuthProvider({ children }) {
       try {
         const { data, error } = await supabase
           .from('perfiles')
-          .select('id, nombre, puesto, rol, avatar_url, usuario:usuarios(email)')
+          .select('id, nombre_completo, puesto, rol, avatar_url, usuario:usuarios(email)')
           .eq('usuario_id', currentSession.user.id)
           .maybeSingle();
 
         if (error) throw error;
-        setProfile(data);
+        setProfile(data ? { ...data, nombre: data.nombre_completo ?? data.nombre } : null);
       } catch (err) {
         console.error('Error cargando perfil', err);
         setProfile(null);

--- a/src/layouts/AppLayout.jsx
+++ b/src/layouts/AppLayout.jsx
@@ -66,10 +66,10 @@ export default function AppLayout() {
           {profile ? (
             <div className="flex items-center gap-3">
               <div className="flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-br from-aifa-light to-aifa-blue font-semibold text-white">
-                {profile.nombre?.[0] ?? 'A'}
+                {(profile.nombre_completo ?? profile.nombre ?? 'A').charAt(0) || 'A'}
               </div>
               <div className="flex-1 text-sm">
-                <p className="font-semibold text-slate-800">{profile.nombre}</p>
+                <p className="font-semibold text-slate-800">{profile.nombre_completo ?? profile.nombre}</p>
                 <p className="text-xs text-slate-500">{profile.puesto ?? profile.rol}</p>
               </div>
               <button

--- a/src/lib/supabaseClient.js
+++ b/src/lib/supabaseClient.js
@@ -12,40 +12,120 @@ export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
   }
 });
 
+function isRelationNotFound(error) {
+  return error?.code === '42P01' || /relation .+ does not exist/i.test(error?.message ?? '');
+}
+
+function isFunctionNotFound(error) {
+  return error?.code === '42883' || /function .+ does not exist/i.test(error?.message ?? '');
+}
+
+function normalizeMeasurement(record) {
+  if (!record) return record;
+  return {
+    ...record,
+    escenario: record.escenario ? record.escenario.toUpperCase() : null,
+    fecha_captura: record.fecha_captura ?? record.creado_en ?? null,
+    fecha_actualizacion:
+      record.fecha_actualizacion ?? record.fecha_ultima_edicion ?? record.actualizado_en ?? null
+  };
+}
+
+function normalizeTarget(record) {
+  if (!record) return record;
+  return {
+    ...record,
+    escenario: record.escenario ? record.escenario.toUpperCase() : null,
+    fecha_captura: record.fecha_captura ?? record.creado_en ?? null,
+    fecha_actualizacion:
+      record.fecha_actualizacion ?? record.fecha_ultima_edicion ?? record.actualizado_en ?? null
+  };
+}
+
+async function fetchFromRelations(relations, builder) {
+  let lastError = null;
+  for (const relation of relations) {
+    const { data, error } = await builder(relation);
+    if (!error) {
+      return data ?? [];
+    }
+    if (!isRelationNotFound(error)) {
+      throw error;
+    }
+    lastError = error;
+  }
+  if (lastError) {
+    throw lastError;
+  }
+  return [];
+}
+
+function sanitizeScenario(payload) {
+  if (!payload) return payload;
+  if ('escenario' in payload && payload.escenario) {
+    return { ...payload, escenario: payload.escenario.toUpperCase() };
+  }
+  if ('escenario' in payload) {
+    return { ...payload, escenario: null };
+  }
+  return payload;
+}
+
 export async function getDashboardSummary() {
-  const { data, error } = await supabase.from('v_dashboard_resumen').select('*');
-  if (error) throw error;
+  return fetchFromRelations(['vw_dashboard_resumen', 'v_dashboard_resumen'], relation =>
+    supabase.from(relation).select('*')
+  );
+}
+
+export async function getDirectorsHighlights() {
+  try {
+    return await fetchFromRelations(
+      ['vw_indicadores_criticos', 'vw_indicadores_alertas', 'vw_indicadores_alerta', 'v_indicadores_criticos'],
+      relation => supabase.from(relation).select('*')
+    );
+  } catch (error) {
+    if (!isRelationNotFound(error)) {
+      throw error;
+    }
+  }
+
+  const { data, error } = await supabase.rpc('kpi_resumen_directivos');
+  if (error) {
+    if (isFunctionNotFound(error)) return [];
+    throw error;
+  }
   return data ?? [];
 }
 
 export async function getIndicators() {
-  const { data, error } = await supabase
-    .from('v_indicadores_area')
-    .select('*')
-    .order('area_nombre', { ascending: true })
-    .order('nombre', { ascending: true });
-  if (error) throw error;
-  return data ?? [];
+  return fetchFromRelations(['vw_indicadores_area', 'vw_indicadores_detalle', 'v_indicadores_area'], relation =>
+    supabase
+      .from(relation)
+      .select('*')
+      .order('area_nombre', { ascending: true })
+      .order('nombre', { ascending: true })
+  );
 }
 
 export async function getIndicatorHistory(indicadorId, { limit = 24 } = {}) {
-  const query = supabase
+  if (!indicadorId) return [];
+  const { data, error } = await supabase
     .from('mediciones')
-    .select('id, indicador_id, periodo, anio, mes, valor, escenario, creado_en')
+    .select('*')
     .eq('indicador_id', indicadorId)
     .order('anio', { ascending: true })
     .order('mes', { ascending: true })
     .limit(limit);
 
-  const { data, error } = await query;
   if (error) throw error;
-  return data ?? [];
+  return (data ?? []).map(normalizeMeasurement);
 }
 
 export async function getIndicatorTargets(indicadorId, { year } = {}) {
+  if (!indicadorId) return [];
   let query = supabase
     .from('indicador_metas')
-    .select('id, indicador_id, anio, mes, escenario, valor, fecha_captura, fecha_ultima_edicion')
+    .select('*')
     .eq('indicador_id', indicadorId)
     .order('anio', { ascending: true })
     .order('mes', { ascending: true });
@@ -56,32 +136,35 @@ export async function getIndicatorTargets(indicadorId, { year } = {}) {
 
   const { data, error } = await query;
   if (error) throw error;
-  return data ?? [];
+  return (data ?? []).map(normalizeTarget);
 }
 
 export async function saveMeasurement(payload) {
-  const { data, error } = await supabase.from('mediciones').insert(payload).select().single();
+  const sanitized = sanitizeScenario(payload);
+  const { data, error } = await supabase.from('mediciones').insert(sanitized).select().single();
   if (error) throw error;
-  return data;
+  return normalizeMeasurement(data);
 }
 
 export async function updateMeasurement(id, payload) {
+  const sanitized = sanitizeScenario(payload);
   const { data, error } = await supabase
     .from('mediciones')
-    .update(payload)
+    .update(sanitized)
     .eq('id', id)
     .select()
     .single();
   if (error) throw error;
-  return data;
+  return normalizeMeasurement(data);
 }
 
 export async function upsertTarget(payload) {
+  const sanitized = sanitizeScenario(payload);
   const { data, error } = await supabase
     .from('indicador_metas')
-    .upsert(payload, { onConflict: 'indicador_id,anio,mes,escenario' })
+    .upsert(sanitized, { onConflict: 'indicador_id,anio,mes,escenario' })
     .select()
     .single();
   if (error) throw error;
-  return data;
+  return normalizeTarget(data);
 }

--- a/src/services/supabaseClient.js
+++ b/src/services/supabaseClient.js
@@ -12,6 +12,65 @@ export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
   }
 });
 
+function isRelationNotFound(error) {
+  return error?.code === '42P01' || /relation .+ does not exist/i.test(error?.message ?? '');
+}
+
+function isFunctionNotFound(error) {
+  return error?.code === '42883' || /function .+ does not exist/i.test(error?.message ?? '');
+}
+
+function normalizeMeasurement(record) {
+  if (!record) return record;
+  return {
+    ...record,
+    escenario: record.escenario ? record.escenario.toUpperCase() : null,
+    fecha_captura: record.fecha_captura ?? record.creado_en ?? null,
+    fecha_actualizacion:
+      record.fecha_actualizacion ?? record.fecha_ultima_edicion ?? record.actualizado_en ?? null
+  };
+}
+
+function normalizeTarget(record) {
+  if (!record) return record;
+  return {
+    ...record,
+    escenario: record.escenario ? record.escenario.toUpperCase() : null,
+    fecha_captura: record.fecha_captura ?? record.creado_en ?? null,
+    fecha_actualizacion:
+      record.fecha_actualizacion ?? record.fecha_ultima_edicion ?? record.actualizado_en ?? null
+  };
+}
+
+async function fetchFromRelations(relations, builder) {
+  let lastError = null;
+  for (const relation of relations) {
+    const { data, error } = await builder(relation);
+    if (!error) {
+      return data ?? [];
+    }
+    if (!isRelationNotFound(error)) {
+      throw error;
+    }
+    lastError = error;
+  }
+  if (lastError) {
+    throw lastError;
+  }
+  return [];
+}
+
+function sanitizeScenario(payload) {
+  if (!payload) return payload;
+  if ('escenario' in payload && payload.escenario) {
+    return { ...payload, escenario: payload.escenario.toUpperCase() };
+  }
+  if ('escenario' in payload) {
+    return { ...payload, escenario: null };
+  }
+  return payload;
+}
+
 export async function signInWithEmail({ email, password }) {
   const { error } = await supabase.auth.signInWithPassword({ email, password });
   if (error) throw error;
@@ -24,45 +83,60 @@ export async function signOut() {
 }
 
 export async function getDashboardSummary() {
-  const { data, error } = await supabase.from('v_dashboard_resumen').select('*');
-  if (error) throw error;
-  return data ?? [];
+  return fetchFromRelations(['vw_dashboard_resumen', 'v_dashboard_resumen'], relation =>
+    supabase.from(relation).select('*')
+  );
 }
 
 export async function getDirectorsHighlights() {
+  try {
+    return await fetchFromRelations(
+      ['vw_indicadores_criticos', 'vw_indicadores_alertas', 'vw_indicadores_alerta', 'v_indicadores_criticos'],
+      relation => supabase.from(relation).select('*')
+    );
+  } catch (error) {
+    if (!isRelationNotFound(error)) {
+      throw error;
+    }
+  }
+
   const { data, error } = await supabase.rpc('kpi_resumen_directivos');
-  if (error) throw error;
+  if (error) {
+    if (isFunctionNotFound(error)) return [];
+    throw error;
+  }
   return data ?? [];
 }
 
 export async function getIndicators() {
-  const { data, error } = await supabase
-    .from('v_indicadores_area')
-    .select('*')
-    .order('area_nombre', { ascending: true })
-    .order('nombre', { ascending: true });
-  if (error) throw error;
-  return data ?? [];
+  return fetchFromRelations(['vw_indicadores_area', 'vw_indicadores_detalle', 'v_indicadores_area'], relation =>
+    supabase
+      .from(relation)
+      .select('*')
+      .order('area_nombre', { ascending: true })
+      .order('nombre', { ascending: true })
+  );
 }
 
 export async function getIndicatorHistory(indicadorId, { limit = 24 } = {}) {
-  const query = supabase
+  if (!indicadorId) return [];
+  const { data, error } = await supabase
     .from('mediciones')
-    .select('id, indicador_id, periodo, anio, mes, valor, escenario, creado_en')
+    .select('*')
     .eq('indicador_id', indicadorId)
     .order('anio', { ascending: true })
     .order('mes', { ascending: true })
     .limit(limit);
 
-  const { data, error } = await query;
   if (error) throw error;
-  return data ?? [];
+  return (data ?? []).map(normalizeMeasurement);
 }
 
 export async function getIndicatorTargets(indicadorId, { year } = {}) {
+  if (!indicadorId) return [];
   let query = supabase
     .from('indicador_metas')
-    .select('id, indicador_id, anio, mes, escenario, valor, fecha_captura, fecha_ultima_edicion')
+    .select('*')
     .eq('indicador_id', indicadorId)
     .order('anio', { ascending: true })
     .order('mes', { ascending: true });
@@ -73,32 +147,35 @@ export async function getIndicatorTargets(indicadorId, { year } = {}) {
 
   const { data, error } = await query;
   if (error) throw error;
-  return data ?? [];
+  return (data ?? []).map(normalizeTarget);
 }
 
 export async function saveMeasurement(payload) {
-  const { data, error } = await supabase.from('mediciones').insert(payload).select().single();
+  const sanitized = sanitizeScenario(payload);
+  const { data, error } = await supabase.from('mediciones').insert(sanitized).select().single();
   if (error) throw error;
-  return data;
+  return normalizeMeasurement(data);
 }
 
 export async function updateMeasurement(id, payload) {
+  const sanitized = sanitizeScenario(payload);
   const { data, error } = await supabase
     .from('mediciones')
-    .update(payload)
+    .update(sanitized)
     .eq('id', id)
     .select()
     .single();
   if (error) throw error;
-  return data;
+  return normalizeMeasurement(data);
 }
 
 export async function upsertTarget(payload) {
+  const sanitized = sanitizeScenario(payload);
   const { data, error } = await supabase
     .from('indicador_metas')
-    .upsert(payload, { onConflict: 'indicador_id,anio,mes,escenario' })
+    .upsert(sanitized, { onConflict: 'indicador_id,anio,mes,escenario' })
     .select()
     .single();
   if (error) throw error;
-  return data;
+  return normalizeTarget(data);
 }

--- a/src/views/capture.js
+++ b/src/views/capture.js
@@ -41,7 +41,7 @@ function buildHistoryTable(history) {
                   <td class="px-4 py-3 text-slate-600">${monthName(item.mes)} ${item.anio}</td>
                   <td class="px-4 py-3 text-right font-semibold text-slate-800">${formatNumber(item.valor)}</td>
                   <td class="px-4 py-3 text-slate-500">${item.escenario ?? '—'}</td>
-                  <td class="px-4 py-3 text-right text-slate-400 text-xs">${formatDate(item.creado_en)}</td>
+                  <td class="px-4 py-3 text-right text-slate-400 text-xs">${formatDate(item.fecha_captura ?? item.creado_en)}</td>
                 </tr>
               `;
             })
@@ -79,7 +79,7 @@ function buildTargetsTable(targets) {
                   <td class="px-4 py-3 text-slate-600">${monthName(item.mes)} ${item.anio}</td>
                   <td class="px-4 py-3 text-right font-semibold text-slate-800">${formatNumber(item.valor)}</td>
                   <td class="px-4 py-3 text-slate-500">${item.escenario ?? '—'}</td>
-                  <td class="px-4 py-3 text-right text-slate-400 text-xs">${formatDate(item.fecha_ultima_edicion)}</td>
+                  <td class="px-4 py-3 text-right text-slate-400 text-xs">${formatDate(item.fecha_actualizacion ?? item.fecha_ultima_edicion)}</td>
                 </tr>
               `;
             })
@@ -148,10 +148,10 @@ export async function renderCapture(container) {
                   <label class="flex flex-col gap-1 text-sm text-slate-600">
                     Escenario
                     <select name="scenario" class="rounded-lg border border-slate-200 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-slate-400">
-                      <option value="real">Real</option>
-                      <option value="bajo">Bajo</option>
-                      <option value="medio">Medio</option>
-                      <option value="alto">Alto</option>
+                      <option value="REAL">Real</option>
+                      <option value="BAJO">Bajo</option>
+                      <option value="MEDIO">Medio</option>
+                      <option value="ALTO">Alto</option>
                     </select>
                   </label>
                 </div>
@@ -190,9 +190,9 @@ export async function renderCapture(container) {
                   <label class="flex flex-col gap-1 text-sm text-slate-600">
                     Escenario
                     <select name="scenario" class="rounded-lg border border-slate-200 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-slate-400">
-                      <option value="bajo">Bajo</option>
-                      <option value="medio">Medio</option>
-                      <option value="alto">Alto</option>
+                      <option value="BAJO">Bajo</option>
+                      <option value="MEDIO">Medio</option>
+                      <option value="ALTO">Alto</option>
                     </select>
                   </label>
                 </div>
@@ -264,14 +264,14 @@ export async function renderCapture(container) {
       submit.disabled = true;
       submit.classList.add('opacity-70');
       const formData = new FormData(form);
-      const scenario = formData.get('scenario');
+      const scenario = (formData.get('scenario') ?? '').toString().toUpperCase();
 
       const payload = {
         indicador_id: state.indicatorId,
         anio: state.year,
         mes: Number(formData.get('month')),
         valor: Number(formData.get('value')),
-        escenario: scenario === 'real' ? null : scenario
+        escenario: scenario || null
       };
 
       try {
@@ -300,7 +300,7 @@ export async function renderCapture(container) {
         indicador_id: state.indicatorId,
         anio: state.year,
         mes: Number(formData.get('month')),
-        escenario: formData.get('scenario'),
+        escenario: (formData.get('scenario') ?? '').toString().toUpperCase(),
         valor: Number(formData.get('value'))
       };
 


### PR DESCRIPTION
## Summary
- update Supabase data accessors to fall back to the renamed views/functions from the new schema and normalize timestamps
- align measurement/target helpers with the new mediciones/indicador_metas columns and uppercase scenarios consistently
- refresh profile usage to read nombre_completo and keep the existing layout initials rendering

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db10353630832e98988cd6d0c57f14