### PR TITLE
Revamp dashboard layout and fix logout

### DIFF
--- a/assets/logo-aifa.svg
+++ b/assets/logo-aifa.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 40" role="img" aria-labelledby="title desc">
+  <title id="title">Logotipo AIFA</title>
+  <desc id="desc">Marca genérica del Aeropuerto Internacional Felipe Ángeles.</desc>
+  <rect width="160" height="40" rx="6" fill="#0d1b2a" />
+  <path
+    d="M33.4 29.5h-6.7l-2 5.7h-6.1L26.3 10h7.3l7.8 25.2h-6.2zm-5.6-4.6h4.5L30 17.8h-.1zM68.7 35.2h-6.1V23.7l-8.6 11.5h-5.4V10h6.1v11.4L63.4 10h5.3v25.2zM96.9 35.2h-6.2l-1.1-3.6h-7.7l-1.2 3.6h-6L83.1 10h7.8l6 25.2zm-8.6-8.7-2.5-8.4-2.6 8.4zM119.5 35.2H113V15h-6.6v-5h19.7v5h-6.6zM140.6 35.7c-6.8 0-11.4-5.1-11.4-13s4.6-13 11.4-13 11.4 5.1 11.4 13-4.6 13-11.4 13zm0-5.4c3.1 0 5.2-2.8 5.2-7.6s-2-7.6-5.2-7.6-5.2 2.8-5.2 7.6 2 7.6 5.2 7.6z"
+    fill="#f1f5f9"
+  />
+</svg>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,8 @@ import LoginPage from './pages/LoginPage.jsx';
 import DashboardPage from './pages/DashboardPage.jsx';
 import IndicatorsPage from './pages/IndicatorsPage.jsx';
 import CapturePage from './pages/CapturePage.jsx';
+import VisualizationPage from './pages/VisualizationPage.jsx';
+import UsersPage from './pages/UsersPage.jsx';
 
 function ProtectedRoute({ children }) {
   const { session, loading } = useAuth();
@@ -31,7 +33,7 @@ export default function App() {
 
   return (
     <Routes>
-      <Route path="/login" element={session ? <Navigate to="/" replace /> : <LoginPage />} />
+      <Route path="/login" element={session ? <Navigate to="/panel-directivos" replace /> : <LoginPage />} />
       <Route
         path="/"
         element={
@@ -40,11 +42,14 @@ export default function App() {
           </ProtectedRoute>
         }
       >
-        <Route index element={<DashboardPage />} />
+        <Route index element={<Navigate to="panel-directivos" replace />} />
+        <Route path="panel-directivos" element={<DashboardPage />} />
+        <Route path="visualizacion" element={<VisualizationPage />} />
         <Route path="indicadores" element={<IndicatorsPage />} />
         <Route path="captura" element={<CapturePage />} />
+        <Route path="usuarios" element={<UsersPage />} />
       </Route>
-      <Route path="*" element={<Navigate to={session ? '/' : '/login'} replace />} />
+      <Route path="*" element={<Navigate to={session ? '/panel-directivos' : '/login'} replace />} />
     </Routes>
   );
 }

--- a/src/config/dashboardConfig.js
+++ b/src/config/dashboardConfig.js
@@ -1,0 +1,166 @@
+export const INDICATOR_OPTION_TEMPLATES = [
+  {
+    id: 'mensual_vs_anterior',
+    icon: 'calendar-month',
+    template:
+      'Cantidad de {{subject}} real mensual del año en curso respecto al mismo periodo del año anterior'
+  },
+  {
+    id: 'trimestral_vs_anterior',
+    icon: 'calendar-quarter',
+    template:
+      'Cantidad de {{subject}} real trimestral del año en curso respecto al mismo periodo del año anterior'
+  },
+  {
+    id: 'anual_vs_anterior',
+    icon: 'calendar-year',
+    template:
+      'Cantidad de {{subject}} real anual del año en curso respecto al mismo periodo del año anterior'
+  },
+  {
+    id: 'escenario_bajo',
+    icon: 'target-low',
+    template:
+      'Cantidad de {{subject}} real del año en curso respecto a la proyección de meta escenario Bajo'
+  },
+  {
+    id: 'escenario_medio',
+    icon: 'target-mid',
+    template:
+      'Cantidad de {{subject}} real del año en curso respecto a la proyección de meta escenario Medio'
+  },
+  {
+    id: 'escenario_alto',
+    icon: 'target-high',
+    template:
+      'Cantidad de {{subject}} real del año en curso respecto a la proyección de meta escenario Alto'
+  }
+];
+
+export const INDICATOR_SECTIONS = [
+  {
+    id: 'operativos',
+    title: 'Indicadores Operativos',
+    description: 'Aviación Comercial y Aviación Carga.',
+    accent: 'indigo',
+    categories: [
+      {
+        id: 'aviacion-comercial-operaciones',
+        label: 'Aviación Comercial Operaciones',
+        subject: 'Aviación Comercial Operaciones',
+        palette: 'indigo',
+        icon: 'plane-operations'
+      },
+      {
+        id: 'aviacion-comercial-pasajeros',
+        label: 'Aviación Comercial Pasajeros',
+        subject: 'Aviación Comercial Pasajeros',
+        palette: 'blue',
+        icon: 'plane-passengers'
+      },
+      {
+        id: 'aviacion-carga-operaciones',
+        label: 'Aviación Carga Operaciones',
+        subject: 'Aviación Carga Operaciones',
+        palette: 'amber',
+        icon: 'cargo-operations'
+      },
+      {
+        id: 'aviacion-carga-toneladas',
+        label: 'Aviación Carga Toneladas',
+        subject: 'Aviación Carga Toneladas',
+        palette: 'orange',
+        icon: 'cargo-weight'
+      }
+    ]
+  },
+  {
+    id: 'fbo',
+    title: 'Indicadores FBO (Aviación General)',
+    description: 'Tráfico de aviación general y ejecutiva.',
+    accent: 'emerald',
+    categories: [
+      {
+        id: 'aviacion-general-operaciones',
+        label: 'Aviación General Operaciones',
+        subject: 'Aviación General Operaciones',
+        palette: 'emerald',
+        icon: 'fbo-operations'
+      },
+      {
+        id: 'aviacion-general-pasajeros',
+        label: 'Aviación General Pasajeros',
+        subject: 'Aviación General Pasajeros',
+        palette: 'teal',
+        icon: 'fbo-passengers'
+      }
+    ]
+  }
+];
+
+export const DIRECTION_FALLBACKS = [
+  {
+    id: 'direccion-operacion',
+    name: 'Dirección de Operación',
+    code: 'DO',
+    palette: 'indigo'
+  },
+  {
+    id: 'direccion-planeacion-estrategica',
+    name: 'Dirección de Planeación Estratégica',
+    code: 'DPE',
+    palette: 'violet'
+  },
+  {
+    id: 'direccion-comercial-servicios',
+    name: 'Dirección Comercial y de Servicios',
+    code: 'DCS',
+    palette: 'amber'
+  },
+  {
+    id: 'direccion-administracion',
+    name: 'Dirección de Administración',
+    code: 'DA',
+    palette: 'sky'
+  },
+  {
+    id: 'direccion-juridica',
+    name: 'Dirección Jurídica',
+    code: 'DJ',
+    palette: 'emerald'
+  }
+];
+
+export function buildIndicatorOptions(category) {
+  return INDICATOR_OPTION_TEMPLATES.map(template => ({
+    id: `${category.id}__${template.id}`,
+    templateId: template.id,
+    icon: template.icon,
+    label: template.template.replace(/\{\{subject\}\}/gi, category.subject)
+  }));
+}
+
+export function normalizeText(value) {
+  return (value ?? '')
+    .toString()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function buildCodeFromName(name) {
+  if (!name) return '';
+  const matches = name.match(/[A-ZÁÉÍÓÚÜÑ]/g);
+  if (matches?.length) {
+    return matches.join('');
+  }
+  return name
+    .split(/\s+/)
+    .slice(0, 3)
+    .map(part => part[0])
+    .join('')
+    .toUpperCase();
+}

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -34,12 +34,12 @@ export function AuthProvider({ children }) {
       try {
         const { data, error } = await supabase
           .from('perfiles')
-          .select('id, nombre, puesto, rol, avatar_url, usuario:usuarios(email)')
+          .select('id, nombre_completo, puesto, rol, avatar_url, usuario:usuarios(email)')
           .eq('usuario_id', currentSession.user.id)
           .maybeSingle();
 
         if (error) throw error;
-        setProfile(data);
+        setProfile(data ? { ...data, nombre: data.nombre_completo ?? data.nombre } : null);
       } catch (err) {
         console.error('Error cargando perfil', err);
         setProfile(null);

--- a/src/layouts/AppLayout.jsx
+++ b/src/layouts/AppLayout.jsx
@@ -1,12 +1,14 @@
-import { Outlet, NavLink, useLocation } from 'react-router-dom';
-import { Menu, BarChart3, ListChecks, ClipboardPen, LogOut } from 'lucide-react';
+import { Outlet, NavLink, useLocation, useNavigate } from 'react-router-dom';
+import { useEffect, useMemo, useState } from 'react';
+import { BarChart3, ListChecks, ClipboardPen, LogOut, Users, Presentation, Menu } from 'lucide-react';
 import { useAuth } from '../context/AuthContext.jsx';
-import { useState } from 'react';
 
 const navigation = [
-  { name: 'Panel directivos', to: '/', icon: BarChart3, exact: true },
+  { name: 'Panel directivos', to: '/panel-directivos', icon: BarChart3, exact: true },
+  { name: 'Visualización', to: '/visualizacion', icon: Presentation },
   { name: 'Consulta de indicadores', to: '/indicadores', icon: ListChecks },
-  { name: 'Captura de indicadores', to: '/captura', icon: ClipboardPen }
+  { name: 'Captura de indicadores', to: '/captura', icon: ClipboardPen },
+  { name: 'Administración de usuarios', to: '/usuarios', icon: Users }
 ];
 
 function classNames(...classes) {
@@ -16,95 +18,142 @@ function classNames(...classes) {
 export default function AppLayout() {
   const { profile, signOut } = useAuth();
   const location = useLocation();
+  const navigate = useNavigate();
   const [mobileOpen, setMobileOpen] = useState(false);
+  const [isSigningOut, setIsSigningOut] = useState(false);
+  const logoUrl = useMemo(() => new URL('../../assets/AIFA_logo.png', import.meta.url).href, []);
+
+  useEffect(() => {
+    setMobileOpen(false);
+  }, [location.pathname]);
+
+  const activeNavigation = useMemo(() => {
+    return (
+      navigation.find(item =>
+        item.exact ? location.pathname === item.to : location.pathname.startsWith(item.to)
+      ) ?? navigation[0]
+    );
+  }, [location.pathname]);
+
+  const handleSignOut = async () => {
+    if (isSigningOut) return;
+    setIsSigningOut(true);
+    try {
+      await signOut();
+      navigate('/login', { replace: true });
+    } catch (error) {
+      console.error('No fue posible cerrar la sesión', error);
+    } finally {
+      setIsSigningOut(false);
+    }
+  };
 
   return (
-    <div className="flex min-h-screen bg-slate-100">
-      <aside
-        className={classNames(
-          'fixed inset-y-0 left-0 z-30 w-72 transform bg-white shadow-xl transition-transform duration-200 lg:translate-x-0',
-          mobileOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'
-        )}
-      >
-        <div className="flex h-20 items-center justify-between border-b border-slate-200 px-6">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-widest text-aifa-blue">AIFA</p>
-            <h1 className="text-lg font-bold text-slate-800">Sistema de indicadores</h1>
-          </div>
-          <button
-            onClick={() => setMobileOpen(false)}
-            className="rounded-md p-2 text-slate-500 transition hover:bg-slate-100 lg:hidden"
-          >
-            <Menu className="h-5 w-5" />
-          </button>
-        </div>
-        <nav className="flex-1 space-y-1 overflow-y-auto px-4 py-6">
-          {navigation.map(item => {
-            const Icon = item.icon;
-            const isActive = item.exact ? location.pathname === item.to : location.pathname.startsWith(item.to);
-            return (
-              <NavLink
-                key={item.to}
-                to={item.to}
-                onClick={() => setMobileOpen(false)}
-                className={() =>
-                  classNames(
-                    'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-all',
-                    isActive
-                      ? 'bg-aifa-blue text-white shadow-lg shadow-aifa-blue/25'
-                      : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'
-                  )
-                }
-              >
-                <Icon className="h-5 w-5" />
-                {item.name}
-              </NavLink>
-            );
-          })}
-        </nav>
-        <div className="border-t border-slate-200 px-6 py-5">
-          {profile ? (
-            <div className="flex items-center gap-3">
-              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-br from-aifa-light to-aifa-blue font-semibold text-white">
-                {profile.nombre?.[0] ?? 'A'}
-              </div>
-              <div className="flex-1 text-sm">
-                <p className="font-semibold text-slate-800">{profile.nombre}</p>
-                <p className="text-xs text-slate-500">{profile.puesto ?? profile.rol}</p>
-              </div>
-              <button
-                onClick={signOut}
-                className="rounded-md p-2 text-slate-500 transition hover:bg-slate-100 hover:text-aifa-blue"
-              >
-                <LogOut className="h-5 w-5" />
-              </button>
+    <div className="flex min-h-screen flex-col bg-slate-100">
+      <header className="relative z-20 border-b border-slate-200 bg-white/95 shadow-sm backdrop-blur">
+        <div className="mx-auto flex h-20 w-full max-w-7xl items-center justify-between gap-6 px-4 sm:px-6 lg:px-8">
+          <div className="flex flex-1 items-center gap-4">
+            <img src={logoUrl} alt="Logotipo AIFA" className="h-12 w-auto" />
+            <div className="hidden sm:block">
+              <p className="text-xs font-semibold uppercase tracking-[0.4em] text-aifa-blue">AIFA</p>
+              <h1 className="text-sm font-semibold text-slate-700">Sistema de indicadores</h1>
             </div>
-          ) : (
-            <p className="text-sm text-slate-500">Sesión no disponible</p>
-          )}
-        </div>
-      </aside>
-      <div className="flex flex-1 flex-col lg:pl-72">
-        <header className="sticky top-0 z-20 border-b border-slate-200 bg-white/80 backdrop-blur">
-          <div className="flex h-20 items-center justify-between px-4 sm:px-6">
+          </div>
+
+          <nav className="hidden flex-1 items-center justify-center gap-1 lg:flex">
+            {navigation.map(item => {
+              const Icon = item.icon;
+              const isActive = item.exact
+                ? location.pathname === item.to
+                : location.pathname.startsWith(item.to);
+              return (
+                <NavLink
+                  key={item.to}
+                  to={item.to}
+                  className={() =>
+                    classNames(
+                      'flex items-center gap-2 rounded-full px-4 py-2 text-sm font-medium transition-all',
+                      isActive
+                        ? 'bg-aifa-blue text-white shadow-lg shadow-aifa-blue/25'
+                        : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'
+                    )
+                  }
+                >
+                  <Icon className="h-4 w-4" />
+                  {item.name}
+                </NavLink>
+              );
+            })}
+          </nav>
+
+          <div className="flex flex-1 items-center justify-end gap-3">
+            {profile ? (
+              <div className="flex items-center gap-3">
+                <div className="hidden text-right text-xs sm:block">
+                  <p className="font-semibold text-slate-800">{profile.nombre_completo ?? profile.nombre}</p>
+                  <p className="text-[11px] uppercase tracking-widest text-slate-400">{profile.puesto ?? profile.rol}</p>
+                </div>
+                <button
+                  onClick={handleSignOut}
+                  disabled={isSigningOut}
+                  className="inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-1.5 text-sm font-medium text-slate-600 transition hover:border-aifa-blue hover:text-aifa-blue disabled:cursor-not-allowed disabled:opacity-70"
+                >
+                  <LogOut className="h-4 w-4" />
+                  <span className="hidden sm:inline">Cerrar sesión</span>
+                </button>
+              </div>
+            ) : (
+              <p className="text-sm text-slate-500">Sesión no disponible</p>
+            )}
             <button
-              onClick={() => setMobileOpen(prev => !prev)}
-              className="rounded-md p-2 text-slate-500 transition hover:bg-slate-100 lg:hidden"
+              onClick={() => setMobileOpen(open => !open)}
+              className="rounded-full border border-slate-200 p-2 text-slate-600 transition hover:border-aifa-blue hover:text-aifa-blue lg:hidden"
+              aria-label="Abrir navegación"
             >
               <Menu className="h-5 w-5" />
             </button>
-            <div className="ml-auto text-right">
-              <p className="text-xs uppercase tracking-widest text-slate-400">Panel</p>
-              <p className="font-semibold text-slate-700">
-                {navigation.find(item => location.pathname.startsWith(item.to))?.name ?? 'Panel'}
-              </p>
-            </div>
           </div>
-        </header>
-        <main className="flex-1 px-4 py-6 sm:px-6 lg:px-8">
+        </div>
+
+        {mobileOpen && (
+          <div className="border-t border-slate-200 bg-white px-4 py-4 shadow-inner lg:hidden">
+            <nav className="flex flex-col gap-2">
+              {navigation.map(item => {
+                const Icon = item.icon;
+                const isActive = item.exact
+                  ? location.pathname === item.to
+                  : location.pathname.startsWith(item.to);
+                return (
+                  <NavLink
+                    key={item.to}
+                    to={item.to}
+                    className={() =>
+                      classNames(
+                        'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-all',
+                        isActive
+                          ? 'bg-aifa-blue text-white shadow'
+                          : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'
+                      )
+                    }
+                  >
+                    <Icon className="h-4 w-4" />
+                    {item.name}
+                  </NavLink>
+                );
+              })}
+            </nav>
+          </div>
+        )}
+      </header>
+
+      <main className="flex-1">
+        <div className="mx-auto w-full max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+          <div className="mb-6 text-sm uppercase tracking-widest text-slate-400">
+            {activeNavigation.name}
+          </div>
           <Outlet />
-        </main>
-      </div>
+        </div>
+      </main>
     </div>
   );
 }

--- a/src/lib/supabaseClient.js
+++ b/src/lib/supabaseClient.js
@@ -12,40 +12,244 @@ export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
   }
 });
 
+function isRelationNotFound(error) {
+  return error?.code === '42P01' || /relation .+ does not exist/i.test(error?.message ?? '');
+}
+
+function isFunctionNotFound(error) {
+  return error?.code === '42883' || /function .+ does not exist/i.test(error?.message ?? '');
+}
+
+function normalizeStatus(value) {
+  const text = value?.toString().toLowerCase() ?? '';
+  return typeof text.normalize === 'function'
+    ? text.normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+    : text;
+}
+
+function normalizeMeasurement(record) {
+  if (!record) return record;
+  return {
+    ...record,
+    escenario: record.escenario ? record.escenario.toUpperCase() : null,
+    fecha_captura: record.fecha_captura ?? record.creado_en ?? null,
+    fecha_actualizacion:
+      record.fecha_actualizacion ?? record.fecha_ultima_edicion ?? record.actualizado_en ?? null
+  };
+}
+
+function normalizeTarget(record) {
+  if (!record) return record;
+  return {
+    ...record,
+    escenario: record.escenario ? record.escenario.toUpperCase() : null,
+    fecha_captura: record.fecha_captura ?? record.creado_en ?? null,
+    fecha_actualizacion:
+      record.fecha_actualizacion ?? record.fecha_ultima_edicion ?? record.actualizado_en ?? null
+  };
+}
+
+function sanitizeScenario(payload) {
+  if (!payload) return payload;
+  if ('escenario' in payload && payload.escenario) {
+    return { ...payload, escenario: payload.escenario.toUpperCase() };
+  }
+  if ('escenario' in payload) {
+    return { ...payload, escenario: null };
+  }
+  return payload;
+}
+
 export async function getDashboardSummary() {
-  const { data, error } = await supabase.from('v_dashboard_resumen').select('*');
-  if (error) throw error;
+  const relations = [
+    'v_dashboard_resumen',
+    'v_dashboard_resumen_v2',
+    'vw_dashboard_resumen',
+    'vw_dashboard_resumen_v2',
+    'dashboard_resumen',
+    'dashboard_resumen_view',
+    'dashboard_resumen_vista',
+    'dashboard_resumen_general',
+    'resumen_dashboard',
+    'vista_dashboard_resumen',
+    'vista_dashboard_resumen_v2'
+  ];
+
+  for (const relation of relations) {
+    const { data, error } = await supabase.from(relation).select('*');
+
+    if (!error) {
+      return data ?? [];
+    }
+
+    if (!isRelationNotFound(error)) {
+      throw error;
+    }
+  }
+
+  return [];
+}
+
+export async function getDirectorsHighlights() {
+  const highlightRelations = [
+    'v_indicadores_criticos',
+    'v_indicadores_prioritarios',
+    'vw_indicadores_criticos',
+    'vw_indicadores_prioritarios',
+    'vw_indicadores_alertas',
+    'vw_indicadores_alerta',
+    'indicadores_criticos',
+    'indicadores_prioritarios',
+    'indicadores_alertas',
+    'indicadores_directivos_resumen',
+    'resumen_indicadores_directivos',
+    'resumen_indicadores_prioritarios',
+    'vista_indicadores_criticos',
+    'vista_indicadores_prioritarios'
+  ];
+
+  for (const relation of highlightRelations) {
+    const { data, error } = await supabase.from(relation).select('*');
+
+    if (!error) {
+      return data ?? [];
+    }
+
+    if (!isRelationNotFound(error)) {
+      throw error;
+    }
+  }
+
+  const indicatorRelations = [
+    'v_indicadores_area',
+    'v_indicadores',
+    'vw_indicadores_area',
+    'vw_indicadores_detalle',
+    'vw_indicadores',
+    'indicadores_area',
+    'indicadores',
+    'vista_indicadores_area',
+    'vista_indicadores'
+  ];
+
+  for (const relation of indicatorRelations) {
+    const { data: indicators, error } = await supabase.from(relation).select('*');
+
+    if (error) {
+      if (isRelationNotFound(error)) {
+        continue;
+      }
+      throw error;
+    }
+
+    if (indicators?.length) {
+      const criticalIndicators = indicators.filter(record => {
+        if (record == null || typeof record !== 'object') return false;
+        if ('es_critico' in record) return Boolean(record.es_critico);
+        if ('es_alerta' in record) return Boolean(record.es_alerta);
+        if ('critico' in record) return Boolean(record.critico);
+        if ('alerta' in record) return Boolean(record.alerta);
+        const status =
+          record.nivel_alerta ??
+          record.estatus ??
+          record.estado ??
+          record.estatus_alerta ??
+          record.color_alerta ??
+          '';
+        return ['critico', 'alerta', 'rojo'].includes(normalizeStatus(status));
+      });
+
+      if (criticalIndicators.length) {
+        return criticalIndicators.map(item => ({
+          ...item,
+          valor_actual: item.valor_actual ?? item.ultima_medicion_valor ?? item.valor ?? null,
+          meta: item.meta ?? item.valor_meta ?? item.meta_actual ?? null,
+          actualizado_en: item.actualizado_en ?? item.fecha_actualizacion ?? item.ultima_medicion_fecha ?? null,
+          area: item.area ?? item.area_nombre ?? null
+        }));
+      }
+    }
+  }
+
+  const { data, error } = await supabase.rpc('kpi_resumen_directivos');
+  if (error) {
+    if (isFunctionNotFound(error)) return [];
+    throw error;
+  }
   return data ?? [];
 }
 
 export async function getIndicators() {
-  const { data, error } = await supabase
-    .from('v_indicadores_area')
-    .select('*')
-    .order('area_nombre', { ascending: true })
-    .order('nombre', { ascending: true });
-  if (error) throw error;
-  return data ?? [];
+  const relations = [
+    'v_indicadores_area',
+    'v_indicadores',
+    'vw_indicadores_area',
+    'vw_indicadores_detalle',
+    'vw_indicadores',
+    'indicadores_area',
+    'indicadores',
+    'vista_indicadores_area',
+    'vista_indicadores'
+  ];
+
+  for (const relation of relations) {
+    const { data, error } = await supabase
+      .from(relation)
+      .select('*')
+      .order('area_nombre', { ascending: true })
+      .order('nombre', { ascending: true });
+
+    if (!error) {
+      return data ?? [];
+    }
+
+    if (!isRelationNotFound(error)) {
+      throw error;
+    }
+  }
+
+  return [];
 }
 
 export async function getIndicatorHistory(indicadorId, { limit = 24 } = {}) {
-  const query = supabase
-    .from('mediciones')
-    .select('id, indicador_id, periodo, anio, mes, valor, escenario, creado_en')
-    .eq('indicador_id', indicadorId)
-    .order('anio', { ascending: true })
-    .order('mes', { ascending: true })
-    .limit(limit);
+  if (!indicadorId) return [];
 
-  const { data, error } = await query;
-  if (error) throw error;
-  return data ?? [];
+  const relations = [
+    'v_mediciones_historico',
+    'v_mediciones_historico_v2',
+    'mediciones_historico',
+    'mediciones_historico_view',
+    'vista_mediciones_historico',
+    'vw_mediciones_historico',
+    'mediciones'
+  ];
+
+  for (const relation of relations) {
+    const { data, error } = await supabase
+      .from(relation)
+      .select('*')
+      .eq('indicador_id', indicadorId)
+      .order('anio', { ascending: true })
+      .order('mes', { ascending: true })
+      .limit(limit);
+
+    if (!error) {
+      return (data ?? []).map(normalizeMeasurement);
+    }
+
+    if (!isRelationNotFound(error)) {
+      throw error;
+    }
+  }
+
+  return [];
 }
 
 export async function getIndicatorTargets(indicadorId, { year } = {}) {
+  if (!indicadorId) return [];
   let query = supabase
     .from('indicador_metas')
-    .select('id, indicador_id, anio, mes, escenario, valor, fecha_captura, fecha_ultima_edicion')
+    .select('*')
     .eq('indicador_id', indicadorId)
     .order('anio', { ascending: true })
     .order('mes', { ascending: true });
@@ -56,32 +260,81 @@ export async function getIndicatorTargets(indicadorId, { year } = {}) {
 
   const { data, error } = await query;
   if (error) throw error;
-  return data ?? [];
+  return (data ?? []).map(normalizeTarget);
 }
 
 export async function saveMeasurement(payload) {
-  const { data, error } = await supabase.from('mediciones').insert(payload).select().single();
+  const sanitized = sanitizeScenario(payload);
+  const { data, error } = await supabase.from('mediciones').insert(sanitized).select().single();
   if (error) throw error;
-  return data;
+  return normalizeMeasurement(data);
 }
 
 export async function updateMeasurement(id, payload) {
+  const sanitized = sanitizeScenario(payload);
   const { data, error } = await supabase
     .from('mediciones')
-    .update(payload)
+    .update(sanitized)
     .eq('id', id)
     .select()
     .single();
   if (error) throw error;
-  return data;
+  return normalizeMeasurement(data);
 }
 
 export async function upsertTarget(payload) {
+  const sanitized = sanitizeScenario(payload);
   const { data, error } = await supabase
     .from('indicador_metas')
-    .upsert(payload, { onConflict: 'indicador_id,anio,mes,escenario' })
+    .upsert(sanitized, { onConflict: 'indicador_id,anio,mes,escenario' })
     .select()
     .single();
   if (error) throw error;
-  return data;
+  return normalizeTarget(data);
+}
+
+function normalizeUser(record) {
+  if (!record) return null;
+  const email = record.email ?? record.correo ?? record.usuario?.email ?? record.usuario_email ?? null;
+  const lastAccess =
+    record.ultimo_acceso ?? record.ultima_conexion ?? record.ultimo_login ?? record.actualizado_en ?? null;
+  return {
+    id:
+      record.id ??
+      record.usuario_id ??
+      email ??
+      record.nombre_completo ??
+      record.nombre ??
+      `usuario-${Math.random().toString(36).slice(2)}`,
+    nombre: record.nombre_completo ?? record.nombre ?? record.full_name ?? 'Sin nombre',
+    puesto: record.puesto ?? record.cargo ?? null,
+    rol: record.rol ?? record.perfil ?? record.tipo ?? null,
+    email: email ?? '—',
+    direccion: record.direccion ?? record.area ?? record.area_nombre ?? record.subdireccion ?? null,
+    ultimo_acceso: lastAccess
+  };
+}
+
+export async function getUsers() {
+  const relationCandidates = [
+    { relation: 'v_usuarios_sistema', select: 'id,nombre_completo,nombre,puesto,rol,correo,email,direccion,subdireccion,ultima_conexion,ultimo_acceso,usuario:usuarios(email,ultimo_acceso)' },
+    { relation: 'vw_usuarios', select: 'id,nombre_completo,nombre,puesto,rol,correo,email,direccion,ultima_conexion' },
+    { relation: 'usuarios_detalle', select: 'id,nombre_completo,nombre,puesto,rol,correo,email,direccion,ultima_conexion' },
+    { relation: 'usuarios', select: 'id,nombre,correo,rol,ultimo_acceso' },
+    { relation: 'perfiles', select: 'id,nombre_completo,nombre,puesto,rol,usuario:usuarios(email,ultimo_acceso)' }
+  ];
+
+  for (const candidate of relationCandidates) {
+    const { data, error } = await supabase.from(candidate.relation).select(candidate.select);
+
+    if (!error) {
+      return (data ?? []).map(normalizeUser).filter(Boolean);
+    }
+
+    if (!isRelationNotFound(error)) {
+      throw error;
+    }
+  }
+
+  return [];
 }

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -17,67 +17,172 @@ import {
   XAxis,
   YAxis
 } from 'recharts';
-import { AlertTriangle, BarChart3, Clock, Plane, TrendingUp } from 'lucide-react';
+import {
+  Activity,
+  AlertTriangle,
+  BarChart3,
+  CalendarClock,
+  CalendarDays,
+  CalendarRange,
+  ChevronDown,
+  CircleGauge,
+  Goal,
+  Layers3,
+  Package,
+  Plane,
+  PlaneTakeoff,
+  TrendingDown,
+  TrendingUp,
+  Users,
+  Weight
+} from 'lucide-react';
 import classNames from 'classnames';
-
-const OPERATIVE_NAMES = [
-  'Aviación Comercial Pasajeros',
-  'Aviación Comercial Operaciones',
-  'Aviación Carga Operaciones',
-  'Aviación Carga Toneladas'
-];
-
-const FBO_NAMES = ['Aviación General Pasajeros', 'Aviación General Operaciones'];
+import {
+  INDICATOR_SECTIONS,
+  DIRECTION_FALLBACKS,
+  buildIndicatorOptions,
+  normalizeText,
+  buildCodeFromName
+} from '../config/dashboardConfig.js';
 
 const SUMMARY_FIELDS = [
   { key: 'total_indicadores', label: 'Indicadores monitoreados', icon: BarChart3 },
-  { key: 'indicadores_con_metas', label: 'Indicadores con metas', icon: TrendingUp },
-  { key: 'indicadores_sin_actualizar', label: 'Indicadores pendientes', icon: Clock },
-  { key: 'porcentaje_cumplimiento', label: 'Cumplimiento promedio', icon: Plane, type: 'percentage' }
+  { key: 'indicadores_con_metas', label: 'Indicadores con metas', icon: Goal },
+  { key: 'indicadores_sin_actualizar', label: 'Indicadores pendientes', icon: Layers3 },
+  { key: 'porcentaje_cumplimiento', label: 'Cumplimiento promedio', icon: CircleGauge, type: 'percentage' }
 ];
 
-function IndicatorButton({ indicator, active, onClick }) {
-  const Icon = OPERATIVE_NAMES.includes(indicator.nombre) ? Plane : TrendingUp;
-  return (
-    <button
-      onClick={onClick}
-      className={classNames(
-        'w-full rounded-xl border px-4 py-3 text-left transition-all',
-        active
-          ? 'border-transparent bg-gradient-to-r from-aifa-blue to-aifa-light text-white shadow-lg shadow-aifa-blue/30'
-          : 'border-slate-200 bg-white text-slate-700 hover:border-aifa-light hover:bg-aifa-light/10'
-      )}
-    >
-      <div className="flex items-center justify-between">
-        <div>
-          <p className="text-sm font-semibold">{indicator.nombre}</p>
-          <p className="text-xs text-slate-400">{indicator.area_nombre}</p>
-        </div>
-        <Icon className="h-5 w-5 opacity-80" />
-      </div>
-      <div className="mt-3 flex items-center gap-4 text-xs text-slate-500">
-        <span>
-          Última medición:
-          <strong className="ml-1 text-slate-900">
-            {formatNumber(indicator.ultima_medicion_valor)} {indicator.unidad_medida ?? ''}
-          </strong>
-        </span>
-        {indicator.ultima_medicion_fecha && (
-          <span>
-            Actualizado {new Date(indicator.ultima_medicion_fecha).toLocaleDateString('es-MX')}
-          </span>
-        )}
-      </div>
-    </button>
-  );
-}
+const PALETTES = {
+  indigo: {
+    border: 'border-indigo-100',
+    background: 'bg-indigo-50/80',
+    icon: 'text-indigo-500',
+    badge: 'bg-indigo-100 text-indigo-700',
+    option: {
+      idle: 'border-indigo-100 hover:border-indigo-200 hover:bg-white',
+      active: 'border-indigo-200 bg-white shadow-lg shadow-indigo-200/60 text-indigo-900'
+    },
+    chevron: 'text-indigo-500'
+  },
+  blue: {
+    border: 'border-blue-100',
+    background: 'bg-blue-50/80',
+    icon: 'text-blue-500',
+    badge: 'bg-blue-100 text-blue-700',
+    option: {
+      idle: 'border-blue-100 hover:border-blue-200 hover:bg-white',
+      active: 'border-blue-200 bg-white shadow-lg shadow-blue-200/60 text-blue-900'
+    },
+    chevron: 'text-blue-500'
+  },
+  amber: {
+    border: 'border-amber-100',
+    background: 'bg-amber-50/80',
+    icon: 'text-amber-500',
+    badge: 'bg-amber-100 text-amber-700',
+    option: {
+      idle: 'border-amber-100 hover:border-amber-200 hover:bg-white',
+      active: 'border-amber-200 bg-white shadow-lg shadow-amber-200/60 text-amber-900'
+    },
+    chevron: 'text-amber-500'
+  },
+  orange: {
+    border: 'border-orange-100',
+    background: 'bg-orange-50/80',
+    icon: 'text-orange-500',
+    badge: 'bg-orange-100 text-orange-700',
+    option: {
+      idle: 'border-orange-100 hover:border-orange-200 hover:bg-white',
+      active: 'border-orange-200 bg-white shadow-lg shadow-orange-200/60 text-orange-900'
+    },
+    chevron: 'text-orange-500'
+  },
+  emerald: {
+    border: 'border-emerald-100',
+    background: 'bg-emerald-50/80',
+    icon: 'text-emerald-500',
+    badge: 'bg-emerald-100 text-emerald-700',
+    option: {
+      idle: 'border-emerald-100 hover:border-emerald-200 hover:bg-white',
+      active: 'border-emerald-200 bg-white shadow-lg shadow-emerald-200/60 text-emerald-900'
+    },
+    chevron: 'text-emerald-500'
+  },
+  teal: {
+    border: 'border-teal-100',
+    background: 'bg-teal-50/80',
+    icon: 'text-teal-500',
+    badge: 'bg-teal-100 text-teal-700',
+    option: {
+      idle: 'border-teal-100 hover:border-teal-200 hover:bg-white',
+      active: 'border-teal-200 bg-white shadow-lg shadow-teal-200/60 text-teal-900'
+    },
+    chevron: 'text-teal-500'
+  },
+  violet: {
+    border: 'border-violet-100',
+    background: 'bg-violet-50/80',
+    icon: 'text-violet-500',
+    badge: 'bg-violet-100 text-violet-700',
+    option: {
+      idle: 'border-violet-100 hover:border-violet-200 hover:bg-white',
+      active: 'border-violet-200 bg-white shadow-lg shadow-violet-200/60 text-violet-900'
+    },
+    chevron: 'text-violet-500'
+  },
+  sky: {
+    border: 'border-sky-100',
+    background: 'bg-sky-50/80',
+    icon: 'text-sky-500',
+    badge: 'bg-sky-100 text-sky-700',
+    option: {
+      idle: 'border-sky-100 hover:border-sky-200 hover:bg-white',
+      active: 'border-sky-200 bg-white shadow-lg shadow-sky-200/60 text-sky-900'
+    },
+    chevron: 'text-sky-500'
+  },
+  slate: {
+    border: 'border-slate-200',
+    background: 'bg-slate-50/80',
+    icon: 'text-slate-500',
+    badge: 'bg-slate-100 text-slate-600',
+    option: {
+      idle: 'border-slate-200 hover:border-slate-300 hover:bg-white',
+      active: 'border-slate-300 bg-white shadow-lg shadow-slate-200/60 text-slate-900'
+    },
+    chevron: 'text-slate-500'
+  }
+};
+
+const OPTION_ICON_MAP = {
+  'calendar-month': CalendarDays,
+  'calendar-quarter': CalendarClock,
+  'calendar-year': CalendarRange,
+  'target-low': TrendingDown,
+  'target-mid': Activity,
+  'target-high': Goal
+};
+
+const CARD_ICON_MAP = {
+  'plane-operations': PlaneTakeoff,
+  'plane-passengers': Users,
+  'cargo-operations': Package,
+  'cargo-weight': Weight,
+  'fbo-operations': Plane,
+  'fbo-passengers': Users
+};
+
+const DIRECTION_ICON = Users;
 
 function SummaryCards({ summary, loading }) {
   if (loading) {
     return (
       <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
         {SUMMARY_FIELDS.map(field => (
-          <div key={field.key} className="animate-pulse rounded-2xl bg-white/60 p-6 shadow">
+          <div
+            key={field.key}
+            className="h-28 animate-pulse rounded-2xl border border-slate-100 bg-white/70 p-6 shadow-sm"
+          >
             <div className="h-4 w-24 rounded bg-slate-200" />
             <div className="mt-4 h-8 w-32 rounded bg-slate-200" />
           </div>
@@ -102,7 +207,7 @@ function SummaryCards({ summary, loading }) {
         return (
           <div
             key={field.key}
-            className="relative overflow-hidden rounded-2xl bg-white p-6 shadow transition hover:shadow-lg"
+            className="relative overflow-hidden rounded-2xl border border-slate-100 bg-white p-6 shadow transition hover:shadow-lg"
           >
             <div className="absolute -top-10 -right-10 h-32 w-32 rounded-full bg-aifa-light/10" />
             <div className="flex items-center justify-between">
@@ -201,31 +306,256 @@ function IndicatorChart({ history = [], targets = [] }) {
   );
 }
 
+function IndicatorOption({ option, theme, onSelect, isActive }) {
+  const Icon = OPTION_ICON_MAP[option.icon] ?? BarChart3;
+  return (
+    <button
+      type="button"
+      onClick={() => option.indicator && onSelect(option)}
+      disabled={!option.indicator}
+      className={classNames(
+        'flex w-full items-start gap-3 rounded-xl border px-4 py-3 text-left text-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
+        option.indicator
+          ? theme.option.idle
+          : 'border-dashed border-slate-200 bg-white/60 text-slate-400 cursor-not-allowed',
+        isActive && option.indicator ? theme.option.active : null,
+        isActive && !option.indicator ? 'border-slate-300 bg-white' : null,
+        option.indicator ? 'focus-visible:ring-aifa-light' : 'focus-visible:ring-slate-200'
+      )}
+    >
+      <span
+        className={classNames(
+          'flex h-10 w-10 items-center justify-center rounded-full bg-white shadow-sm',
+          option.indicator ? theme.icon : 'text-slate-400'
+        )}
+      >
+        <Icon className="h-5 w-5" />
+      </span>
+      <div className="flex flex-1 flex-col gap-1">
+        <span className="font-medium leading-snug">{option.label}</span>
+        {option.indicator ? (
+          <span className="text-xs text-slate-500">
+            Último valor: {formatNumber(option.indicator.ultima_medicion_valor)}{' '}
+            {option.indicator.unidad_medida ?? ''}
+          </span>
+        ) : (
+          <span className="text-xs text-slate-400">Sin asignar</span>
+        )}
+      </div>
+      {option.indicator?.ultima_medicion_fecha && (
+        <div className="text-right text-xs text-slate-400">
+          Actualizado
+          <br />
+          {new Date(option.indicator.ultima_medicion_fecha).toLocaleDateString('es-MX')}
+        </div>
+      )}
+    </button>
+  );
+}
+
+function IndicatorCard({
+  category,
+  options,
+  isOpen,
+  onToggle,
+  onSelect,
+  activeOptionId
+}) {
+  const theme = PALETTES[category.palette] ?? PALETTES.slate;
+  const CardIcon = CARD_ICON_MAP[category.icon] ?? BarChart3;
+  const assignedCount = options.filter(option => option.indicator).length;
+
+  return (
+    <div className={classNames('overflow-hidden rounded-2xl border bg-white shadow-sm', theme.border)}>
+      <button
+        type="button"
+        onClick={onToggle}
+        className={classNames(
+          'flex w-full items-center justify-between gap-4 px-5 py-4 text-left transition',
+          theme.background,
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-aifa-light'
+        )}
+      >
+        <div className="flex flex-1 items-center gap-3">
+          <span className={classNames('flex h-11 w-11 items-center justify-center rounded-full bg-white shadow', theme.icon)}>
+            <CardIcon className="h-6 w-6" />
+          </span>
+          <div>
+            <p className="text-base font-semibold text-slate-800">{category.label}</p>
+            <p className={classNames('text-xs font-medium', theme.badge)}>
+              {assignedCount ? `${assignedCount} opción${assignedCount === 1 ? '' : 'es'} asignada${
+                assignedCount === 1 ? '' : 's'
+              }` : 'Sin asignar'}
+            </p>
+          </div>
+        </div>
+        <ChevronDown className={classNames('h-5 w-5 transition-transform', theme.chevron, isOpen && 'rotate-180')} />
+      </button>
+      <div
+        className={classNames(
+          'grid transition-[grid-template-rows] duration-300 ease-in-out',
+          isOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
+        )}
+      >
+        <div className="min-h-0 overflow-hidden border-t border-slate-100 bg-white px-5 py-4">
+          <div className="flex flex-col gap-3">
+            {options.map(option => (
+              <IndicatorOption
+                key={option.id}
+                option={option}
+                theme={theme}
+                onSelect={onSelect}
+                isActive={activeOptionId === option.id}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DirectionCard({ direction, isOpen, onToggle }) {
+  const theme = PALETTES[direction.palette] ?? PALETTES.slate;
+  return (
+    <div className={classNames('overflow-hidden rounded-2xl border bg-white shadow-sm', theme.border)}>
+      <button
+        type="button"
+        onClick={onToggle}
+        className={classNames(
+          'flex w-full items-center justify-between gap-4 px-5 py-4 text-left transition',
+          theme.background,
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-aifa-light'
+        )}
+      >
+        <div className="flex flex-1 items-center gap-3">
+          <span className={classNames('flex h-11 w-11 items-center justify-center rounded-full bg-white shadow', theme.icon)}>
+            <DIRECTION_ICON className="h-6 w-6" />
+          </span>
+          <div>
+            <p className="text-base font-semibold text-slate-800">{direction.name}</p>
+            <p className={classNames('inline-flex items-center gap-1 text-xs font-semibold uppercase tracking-widest', theme.badge)}>
+              <span className="rounded-full bg-white/80 px-2 py-0.5 text-[10px] font-bold text-slate-700">
+                {direction.code}
+              </span>
+              {direction.subdirections.length ? `${direction.subdirections.length} subdirección${
+                direction.subdirections.length === 1 ? '' : 'es'
+              }` : 'Sin subdirecciones registradas'}
+            </p>
+          </div>
+        </div>
+        <ChevronDown className={classNames('h-5 w-5 transition-transform', theme.chevron, isOpen && 'rotate-180')} />
+      </button>
+      <div
+        className={classNames(
+          'grid transition-[grid-template-rows] duration-300 ease-in-out',
+          isOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
+        )}
+      >
+        <div className="min-h-0 overflow-hidden border-t border-slate-100 bg-white px-5 py-4">
+          {direction.subdirections.length ? (
+            <ul className="flex flex-col gap-2 text-sm text-slate-600">
+              {direction.subdirections.map(sub => (
+                <li
+                  key={`${direction.id}-${sub.code ?? sub.name}`}
+                  className="flex items-center justify-between gap-4 rounded-xl border border-slate-100 bg-slate-50 px-4 py-2"
+                >
+                  <span className="font-medium text-slate-700">{sub.name}</span>
+                  {sub.code && (
+                    <span className="rounded-full bg-white px-2 py-0.5 text-xs font-semibold text-slate-400">
+                      {sub.code}
+                    </span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="rounded-xl border border-dashed border-slate-200 bg-slate-50/60 px-4 py-3 text-sm text-slate-400">
+              No hay subdirecciones registradas en la matriz.
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function DashboardPage() {
   const [selectedIndicator, setSelectedIndicator] = useState(null);
+  const [selectedOptionId, setSelectedOptionId] = useState(null);
+  const [openCardId, setOpenCardId] = useState(null);
+  const [openDirectionId, setOpenDirectionId] = useState(null);
 
   const summaryQuery = useQuery({ queryKey: ['dashboard-summary'], queryFn: getDashboardSummary });
   const indicatorsQuery = useQuery({ queryKey: ['indicators'], queryFn: getIndicators });
 
-  const operativeIndicators = useMemo(
-    () => (indicatorsQuery.data ?? []).filter(item => OPERATIVE_NAMES.includes(item.nombre)),
-    [indicatorsQuery.data]
-  );
-  const fboIndicators = useMemo(
-    () => (indicatorsQuery.data ?? []).filter(item => FBO_NAMES.includes(item.nombre)),
-    [indicatorsQuery.data]
-  );
+  const indicatorsIndex = useMemo(() => {
+    return (indicatorsQuery.data ?? []).map(record => ({
+      record,
+      normalizedName: normalizeText(record.nombre),
+      normalizedDescription: normalizeText(record.descripcion),
+      normalizedArea: normalizeText(record.area_nombre ?? record.area)
+    }));
+  }, [indicatorsQuery.data]);
+
+  const indicatorSections = useMemo(() => {
+    return INDICATOR_SECTIONS.map(section => ({
+      ...section,
+      categories: section.categories.map(category => {
+        const options = buildIndicatorOptions(category).map(option => {
+          const normalizedOption = normalizeText(option.label);
+          const indicatorMatch = indicatorsIndex.find(entry => {
+            if (!entry.normalizedName && !entry.normalizedDescription) return false;
+            const haystacks = [entry.normalizedName, entry.normalizedDescription].filter(Boolean);
+            const sectionName = normalizeText(category.label);
+            const areaName = entry.normalizedArea;
+            const optionWords = normalizedOption.split(' ').filter(Boolean);
+            return haystacks.some(text => {
+              if (text.includes(normalizedOption)) return true;
+              const containsAllWords = optionWords.every(part => text.includes(part));
+              if (containsAllWords && sectionName && text.includes(sectionName)) {
+                return true;
+              }
+              if (containsAllWords && areaName && text.includes(areaName)) {
+                return true;
+              }
+              return false;
+            });
+          });
+
+          return {
+            ...option,
+            indicator: indicatorMatch?.record ?? null
+          };
+        });
+
+        return {
+          ...category,
+          options
+        };
+      })
+    }));
+  }, [indicatorsIndex]);
 
   useEffect(() => {
-    if (!selectedIndicator && (operativeIndicators.length || fboIndicators.length)) {
-      setSelectedIndicator((operativeIndicators[0] ?? fboIndicators[0])?.id ?? null);
+    if (selectedIndicator) return;
+    for (const section of indicatorSections) {
+      for (const category of section.categories) {
+        const firstAssigned = category.options.find(option => option.indicator);
+        if (firstAssigned) {
+          setSelectedIndicator(firstAssigned.indicator.id);
+          setSelectedOptionId(firstAssigned.id);
+          setOpenCardId(category.id);
+          return;
+        }
+      }
     }
-  }, [selectedIndicator, operativeIndicators, fboIndicators]);
+  }, [indicatorSections, selectedIndicator]);
 
-  const activeIndicator = useMemo(
-    () => (indicatorsQuery.data ?? []).find(item => item.id === selectedIndicator) ?? null,
-    [indicatorsQuery.data, selectedIndicator]
-  );
+  const activeIndicator = useMemo(() => {
+    if (!selectedIndicator) return null;
+    return (indicatorsQuery.data ?? []).find(item => item.id === selectedIndicator) ?? null;
+  }, [indicatorsQuery.data, selectedIndicator]);
 
   const historyQuery = useQuery({
     queryKey: ['indicator-history', selectedIndicator],
@@ -239,78 +569,133 @@ export default function DashboardPage() {
     enabled: Boolean(selectedIndicator)
   });
 
+  const directions = useMemo(() => {
+    const map = new Map();
+    (indicatorsQuery.data ?? []).forEach(item => {
+      const directionName = item.direccion ?? item.direccion_nombre ?? item.area_direccion ?? null;
+      if (!directionName) return;
+      const key = normalizeText(directionName);
+      if (!map.has(key)) {
+        const fallback = DIRECTION_FALLBACKS.find(dir => normalizeText(dir.name) === key);
+        map.set(key, {
+          id: fallback?.id ?? key,
+          name: directionName,
+          code: item.direccion_codigo ?? item.direccion_clave ?? fallback?.code ?? buildCodeFromName(directionName),
+          palette: fallback?.palette ?? 'slate',
+          subdirections: new Map()
+        });
+      }
+      const subName = item.subdireccion ?? item.subdireccion_nombre ?? item.area_subdireccion ?? null;
+      if (subName) {
+        const entry = map.get(key);
+        const subKey = normalizeText(subName);
+        entry.subdirections.set(subKey, {
+          name: subName,
+          code: item.subdireccion_codigo ?? item.subdireccion_clave ?? buildCodeFromName(subName)
+        });
+      }
+    });
+
+    let list = Array.from(map.values()).map(item => ({
+      ...item,
+      subdirections: Array.from(item.subdirections.values()).sort((a, b) => a.name.localeCompare(b.name, 'es'))
+    }));
+
+    const existingKeys = new Set(list.map(item => normalizeText(item.name)));
+    DIRECTION_FALLBACKS.forEach(fallback => {
+      const key = normalizeText(fallback.name);
+      if (!existingKeys.has(key)) {
+        list.push({ ...fallback, subdirections: [] });
+      }
+    });
+
+    return list.sort((a, b) => a.name.localeCompare(b.name, 'es'));
+  }, [indicatorsQuery.data]);
+
   return (
     <div className="space-y-8">
-      <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-slate-900">Panel estratégico de indicadores</h1>
-          <p className="text-sm text-slate-500">
-            Seguimiento ejecutivo de los indicadores clave de operación del Aeropuerto Internacional Felipe Ángeles.
-          </p>
-        </div>
-        {activeIndicator?.ultima_medicion_alerta && (
-          <div className="flex items-center gap-2 rounded-xl border border-amber-300 bg-amber-50 px-4 py-2 text-sm text-amber-700">
-            <AlertTriangle className="h-4 w-4" />
-            {activeIndicator.ultima_medicion_alerta}
+      <header className="space-y-3 rounded-3xl border border-slate-200 bg-gradient-to-br from-white via-slate-50 to-slate-100 p-6 shadow-sm">
+        <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-slate-900">Panel de Análisis de Indicadores</h1>
+            <p className="text-sm text-slate-500">
+              Seleccione un indicador para consultar su tendencia y el comparativo contra las metas planteadas.
+            </p>
           </div>
-        )}
-      </div>
+          {activeIndicator?.ultima_medicion_alerta && (
+            <div className="flex items-center gap-2 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-2 text-sm text-amber-700">
+              <AlertTriangle className="h-4 w-4" />
+              {activeIndicator.ultima_medicion_alerta}
+            </div>
+          )}
+        </div>
+      </header>
 
       <SummaryCards summary={summaryQuery.data} loading={summaryQuery.isLoading} />
 
-      <div className="grid gap-6 xl:grid-cols-[320px,1fr]">
+      <div className="grid gap-6 xl:grid-cols-[420px,1fr]">
         <div className="space-y-6">
-          <section className="rounded-2xl bg-white p-5 shadow">
-            <div className="flex items-center justify-between">
-              <h2 className="text-sm font-semibold uppercase tracking-widest text-slate-400">Indicadores operativos</h2>
-              <span className="rounded-full bg-aifa-light/10 px-2 py-0.5 text-xs font-medium text-aifa-blue">
-                {operativeIndicators.length}
-              </span>
-            </div>
-            <div className="mt-4 space-y-3">
-              {operativeIndicators.map(indicator => (
-                <IndicatorButton
-                  key={indicator.id}
-                  indicator={indicator}
-                  active={indicator.id === selectedIndicator}
-                  onClick={() => setSelectedIndicator(indicator.id)}
-                />
-              ))}
-              {!operativeIndicators.length && <p className="text-sm text-slate-400">No se encontraron indicadores operativos.</p>}
-            </div>
-          </section>
+          {indicatorSections.map(section => (
+            <section key={section.id} className="space-y-4">
+              <header>
+                <h2 className="text-sm font-semibold uppercase tracking-widest text-slate-500">
+                  {section.title}
+                </h2>
+                <p className="text-xs text-slate-400">{section.description}</p>
+              </header>
+              <div className="space-y-3">
+                {section.categories.map(category => (
+                  <IndicatorCard
+                    key={category.id}
+                    category={category}
+                    options={category.options}
+                    isOpen={openCardId === category.id}
+                    onToggle={() => setOpenCardId(prev => (prev === category.id ? null : category.id))}
+                    onSelect={option => {
+                      setSelectedIndicator(option.indicator?.id ?? null);
+                      setSelectedOptionId(option.id);
+                    }}
+                    activeOptionId={selectedOptionId}
+                  />
+                ))}
+              </div>
+            </section>
+          ))}
 
-          <section className="rounded-2xl bg-white p-5 shadow">
-            <div className="flex items-center justify-between">
-              <h2 className="text-sm font-semibold uppercase tracking-widest text-slate-400">Indicadores FBO</h2>
-              <span className="rounded-full bg-aifa-light/10 px-2 py-0.5 text-xs font-medium text-aifa-blue">{fboIndicators.length}</span>
-            </div>
-            <div className="mt-4 space-y-3">
-              {fboIndicators.map(indicator => (
-                <IndicatorButton
-                  key={indicator.id}
-                  indicator={indicator}
-                  active={indicator.id === selectedIndicator}
-                  onClick={() => setSelectedIndicator(indicator.id)}
+          <section className="space-y-4">
+            <header>
+              <h2 className="text-sm font-semibold uppercase tracking-widest text-slate-500">Direcciones</h2>
+              <p className="text-xs text-slate-400">
+                Consulta la estructura de subdirecciones según la matriz institucional asignada.
+              </p>
+            </header>
+            <div className="space-y-3">
+              {directions.map(direction => (
+                <DirectionCard
+                  key={direction.id}
+                  direction={direction}
+                  isOpen={openDirectionId === direction.id}
+                  onToggle={() => setOpenDirectionId(prev => (prev === direction.id ? null : direction.id))}
                 />
               ))}
-              {!fboIndicators.length && <p className="text-sm text-slate-400">No se encontraron indicadores FBO.</p>}
             </div>
           </section>
         </div>
 
         <div className="space-y-6">
-          <section className="rounded-2xl bg-white p-6 shadow">
+          <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
             <div className="flex flex-wrap items-start justify-between gap-4">
               <div>
                 <p className="text-xs uppercase tracking-widest text-slate-400">Indicador seleccionado</p>
-                <h2 className="mt-1 text-xl font-semibold text-slate-800">{activeIndicator?.nombre ?? 'Seleccione un indicador'}</h2>
+                <h2 className="mt-1 text-xl font-semibold text-slate-800">
+                  {activeIndicator?.nombre ?? 'Seleccione un indicador asignado'}
+                </h2>
                 {activeIndicator?.descripcion && (
                   <p className="mt-2 max-w-2xl text-sm text-slate-500">{activeIndicator.descripcion}</p>
                 )}
               </div>
               {activeIndicator?.unidad_medida && (
-                <div className="rounded-xl bg-aifa-blue/10 px-4 py-2 text-right">
+                <div className="rounded-2xl bg-aifa-blue/10 px-4 py-2 text-right">
                   <p className="text-xs uppercase tracking-widest text-aifa-blue">Unidad</p>
                   <p className="text-sm font-semibold text-aifa-blue">{activeIndicator.unidad_medida}</p>
                 </div>
@@ -318,18 +703,21 @@ export default function DashboardPage() {
             </div>
 
             <div className="mt-6 grid gap-4 md:grid-cols-2">
-              <div className="rounded-xl border border-slate-100 bg-slate-50 p-4">
+              <div className="rounded-2xl border border-slate-100 bg-slate-50 p-4">
                 <p className="text-xs uppercase tracking-widest text-slate-400">Valor actual</p>
                 <p className="mt-2 text-2xl font-semibold text-slate-800">
                   {formatNumber(activeIndicator?.ultima_medicion_valor)}
                 </p>
                 {activeIndicator?.ultima_medicion_fecha && (
                   <p className="text-xs text-slate-500">
-                    Actualizado {new Date(activeIndicator.ultima_medicion_fecha).toLocaleDateString('es-MX', { dateStyle: 'medium' })}
+                    Actualizado{' '}
+                    {new Date(activeIndicator.ultima_medicion_fecha).toLocaleDateString('es-MX', {
+                      dateStyle: 'medium'
+                    })}
                   </p>
                 )}
               </div>
-              <div className="rounded-xl border border-slate-100 bg-slate-50 p-4">
+              <div className="rounded-2xl border border-slate-100 bg-slate-50 p-4">
                 <p className="text-xs uppercase tracking-widest text-slate-400">Meta vigente</p>
                 <p className="mt-2 text-2xl font-semibold text-slate-800">
                   {formatNumber(activeIndicator?.meta_vigente_valor)}
@@ -345,9 +733,9 @@ export default function DashboardPage() {
             </div>
           </section>
 
-          <section className="rounded-2xl bg-white p-6 shadow">
-            <h3 className="text-sm font-semibold uppercase tracking-widest text-slate-400">Historial reciente</h3>
-            <div className="mt-4 overflow-hidden rounded-xl border border-slate-100">
+          <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+            <h3 className="text-sm font-semibold uppercase tracking-widest text-slate-500">Historial reciente</h3>
+            <div className="mt-4 overflow-hidden rounded-2xl border border-slate-100">
               <table className="min-w-full divide-y divide-slate-200 text-sm">
                 <thead className="bg-slate-50 text-xs uppercase tracking-widest text-slate-500">
                   <tr>

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -1,10 +1,12 @@
 import { useForm } from 'react-hook-form';
 import { LogIn } from 'lucide-react';
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext.jsx';
 
 export default function LoginPage() {
   const { signIn } = useAuth();
+  const navigate = useNavigate();
   const {
     register,
     handleSubmit,
@@ -21,6 +23,7 @@ export default function LoginPage() {
       if (signInError) {
         throw signInError;
       }
+      navigate('/panel-directivos', { replace: true });
     } catch (err) {
       setError(err.message ?? 'No fue posible iniciar sesión');
     } finally {

--- a/src/pages/UsersPage.jsx
+++ b/src/pages/UsersPage.jsx
@@ -1,0 +1,93 @@
+import { useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { getUsers } from '../lib/supabaseClient.js';
+import { Search, UserPlus } from 'lucide-react';
+import { formatDate } from '../utils/formatters.js';
+
+export default function UsersPage() {
+  const [search, setSearch] = useState('');
+  const usersQuery = useQuery({ queryKey: ['users'], queryFn: getUsers });
+
+  const filteredUsers = useMemo(() => {
+    const term = search.trim().toLowerCase();
+    if (!term) return usersQuery.data ?? [];
+    return (usersQuery.data ?? []).filter(user => {
+      return [user.nombre, user.email, user.rol, user.puesto]
+        .filter(Boolean)
+        .some(value => value.toString().toLowerCase().includes(term));
+    });
+  }, [usersQuery.data, search]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900">Administración de usuarios</h1>
+          <p className="text-sm text-slate-500">
+            Consulte los usuarios con acceso al sistema y su rol dentro de la plataforma.
+          </p>
+        </div>
+        <button
+          type="button"
+          className="inline-flex items-center gap-2 rounded-lg bg-aifa-blue px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-aifa-light focus:outline-none focus:ring-2 focus:ring-aifa-blue/30"
+        >
+          <UserPlus className="h-4 w-4" />
+          Nuevo usuario
+        </button>
+      </div>
+
+      <div className="rounded-2xl bg-white p-5 shadow">
+        <label className="flex items-center gap-3 rounded-xl border border-slate-200 px-4 py-2 text-sm text-slate-500">
+          <Search className="h-4 w-4 text-slate-400" />
+          <input
+            type="search"
+            value={search}
+            onChange={event => setSearch(event.target.value)}
+            placeholder="Buscar por nombre, correo o rol"
+            className="w-full border-none bg-transparent text-sm focus:outline-none"
+          />
+        </label>
+      </div>
+
+      <div className="overflow-hidden rounded-2xl bg-white shadow">
+        <table className="min-w-full divide-y divide-slate-200 text-sm">
+          <thead className="bg-slate-50 text-xs uppercase tracking-widest text-slate-500">
+            <tr>
+              <th className="px-4 py-3 text-left">Nombre</th>
+              <th className="px-4 py-3 text-left">Correo</th>
+              <th className="px-4 py-3 text-left">Puesto</th>
+              <th className="px-4 py-3 text-left">Rol</th>
+              <th className="px-4 py-3 text-right">Último acceso</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100">
+            {filteredUsers.map(user => (
+              <tr key={user.id} className="hover:bg-slate-50/80">
+                <td className="px-4 py-3">
+                  <p className="font-semibold text-slate-800">{user.nombre}</p>
+                  {user.direccion && <p className="text-xs text-slate-400">{user.direccion}</p>}
+                </td>
+                <td className="px-4 py-3 text-slate-600">{user.email}</td>
+                <td className="px-4 py-3 text-slate-600">{user.puesto ?? '—'}</td>
+                <td className="px-4 py-3 text-slate-600">{user.rol ?? '—'}</td>
+                <td className="px-4 py-3 text-right text-slate-500">{formatDate(user.ultimo_acceso)}</td>
+              </tr>
+            ))}
+            {!filteredUsers.length && (
+              <tr>
+                <td colSpan={5} className="px-4 py-10 text-center text-slate-400">
+                  No se encontraron usuarios que coincidan con la búsqueda.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+        {usersQuery.isLoading && (
+          <div className="border-t border-slate-100 bg-slate-50 px-4 py-3 text-center text-xs text-slate-500">
+            Cargando usuarios...
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/VisualizationPage.jsx
+++ b/src/pages/VisualizationPage.jsx
@@ -1,0 +1,286 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import {
+  getIndicators,
+  getIndicatorHistory,
+  getIndicatorTargets
+} from '../lib/supabaseClient.js';
+import { formatMonth, formatNumber } from '../utils/formatters.js';
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend
+} from 'recharts';
+import { Filter, BarChart3 } from 'lucide-react';
+
+function IndicatorHistoryChart({ history = [], targets = [] }) {
+  const chartData = useMemo(() => {
+    const rows = new Map();
+
+    history.forEach(item => {
+      const key = `${item.anio}-${item.mes}`;
+      const value =
+        item.valor ?? item.valor_medido ?? item.valor_real ?? item.valor_actual ?? item.cantidad ?? null;
+      rows.set(key, {
+        key,
+        label: formatMonth(item.anio, item.mes ?? 1),
+        real: value !== null && value !== undefined ? Number(value) : null
+      });
+    });
+
+    targets.forEach(item => {
+      const key = `${item.anio}-${item.mes}`;
+      const scenario = (item.escenario ?? 'meta').toString().toLowerCase();
+      const existing = rows.get(key) ?? {
+        key,
+        label: formatMonth(item.anio, item.mes ?? 1)
+      };
+      const value = item.valor ?? item.valor_meta ?? item.meta ?? null;
+      rows.set(key, {
+        ...existing,
+        [`meta_${scenario}`]: value !== null && value !== undefined ? Number(value) : null
+      });
+    });
+
+    return Array.from(rows.values()).sort((a, b) => (a.key > b.key ? 1 : -1));
+  }, [history, targets]);
+
+  if (!chartData.length) {
+    return (
+      <div className="flex h-72 items-center justify-center rounded-xl border border-dashed border-slate-200 bg-white/80">
+        <div className="text-center text-sm text-slate-500">
+          <BarChart3 className="mx-auto mb-2 h-6 w-6" />
+          No hay suficientes datos históricos para graficar este indicador.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-80 w-full">
+      <ResponsiveContainer>
+        <LineChart data={chartData} margin={{ top: 16, right: 16, left: 8, bottom: 8 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#E2E8F0" />
+          <XAxis dataKey="label" stroke="#94A3B8" fontSize={12} tickLine={false} axisLine={false} />
+          <YAxis stroke="#94A3B8" fontSize={12} tickLine={false} axisLine={false} />
+          <Tooltip
+            formatter={(value, name) => [formatNumber(value, { maximumFractionDigits: 1 }), name]}
+            contentStyle={{ borderRadius: '0.75rem', borderColor: '#CBD5F5' }}
+          />
+          <Legend />
+          <Line type="monotone" dataKey="real" name="Valor real" stroke="#1E3A8A" strokeWidth={3} dot />
+          <Line type="monotone" dataKey="meta_bajo" name="Meta escenario bajo" stroke="#F97316" strokeDasharray="6 3" />
+          <Line type="monotone" dataKey="meta_medio" name="Meta escenario medio" stroke="#0EA5E9" strokeDasharray="6 3" />
+          <Line type="monotone" dataKey="meta_alto" name="Meta escenario alto" stroke="#059669" strokeDasharray="6 3" />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+export default function VisualizationPage() {
+  const [selectedArea, setSelectedArea] = useState(null);
+  const [selectedIndicator, setSelectedIndicator] = useState(null);
+
+  const indicatorsQuery = useQuery({ queryKey: ['indicators'], queryFn: getIndicators });
+
+  const areaOptions = useMemo(() => {
+    const areasMap = new Map();
+    (indicatorsQuery.data ?? []).forEach(item => {
+      const rawId = item.area_id ?? item.areaId ?? item.area ?? item.area_nombre;
+      const areaName = item.area_nombre ?? item.area ?? 'Sin área asignada';
+      const key = rawId === null || rawId === undefined ? 'sin-area' : String(rawId);
+      if (!areasMap.has(key)) {
+        areasMap.set(key, { id: key, name: areaName });
+      }
+    });
+    return Array.from(areasMap.values()).sort((a, b) => a.name.localeCompare(b.name));
+  }, [indicatorsQuery.data]);
+
+  const indicatorsByArea = useMemo(() => {
+    if (!selectedArea) return [];
+    return (indicatorsQuery.data ?? [])
+      .filter(item => {
+        const areaId = item.area_id ?? item.areaId ?? item.area ?? item.area_nombre;
+        return String(areaId) === String(selectedArea);
+      })
+      .sort((a, b) => (a.nombre ?? '').localeCompare(b.nombre ?? ''));
+  }, [indicatorsQuery.data, selectedArea]);
+
+  useEffect(() => {
+    if (!areaOptions.length) return;
+    setSelectedArea(prev => prev ?? areaOptions[0]?.id ?? null);
+  }, [areaOptions]);
+
+  useEffect(() => {
+    if (!indicatorsByArea.length) {
+      setSelectedIndicator(null);
+      return;
+    }
+    setSelectedIndicator(prev => {
+      if (prev && indicatorsByArea.some(indicator => indicator.id === prev)) {
+        return prev;
+      }
+      return indicatorsByArea[0]?.id ?? null;
+    });
+  }, [indicatorsByArea]);
+
+  const activeIndicator = useMemo(() => {
+    if (!selectedIndicator) return null;
+    return (indicatorsQuery.data ?? []).find(item => item.id === selectedIndicator) ?? null;
+  }, [indicatorsQuery.data, selectedIndicator]);
+
+  const historyQuery = useQuery({
+    queryKey: ['visualization-history', selectedIndicator],
+    queryFn: () => getIndicatorHistory(selectedIndicator, { limit: 36 }),
+    enabled: Boolean(selectedIndicator)
+  });
+
+  const targetsQuery = useQuery({
+    queryKey: ['visualization-targets', selectedIndicator],
+    queryFn: () => getIndicatorTargets(selectedIndicator),
+    enabled: Boolean(selectedIndicator)
+  });
+
+  return (
+    <div className="space-y-8">
+      <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900">Visualización de indicadores</h1>
+          <p className="text-sm text-slate-500">
+            Seleccione el área y posteriormente el indicador para consultar su tendencia histórica.
+          </p>
+        </div>
+      </div>
+
+      <div className="grid gap-4 rounded-2xl bg-white p-6 shadow md:grid-cols-2 lg:grid-cols-3">
+        <label className="flex flex-col gap-2">
+          <span className="text-xs font-semibold uppercase tracking-widest text-slate-400">Área</span>
+          <div className="flex items-center gap-2 rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm">
+            <Filter className="h-4 w-4 text-slate-400" />
+            <select
+              value={selectedArea ?? ''}
+              onChange={event => setSelectedArea(event.target.value || null)}
+              className="w-full border-none bg-transparent text-sm focus:outline-none"
+            >
+              {areaOptions.map(area => (
+                <option key={area.id} value={area.id}>
+                  {area.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        </label>
+
+        <label className="flex flex-col gap-2 md:col-span-1 lg:col-span-2">
+          <span className="text-xs font-semibold uppercase tracking-widest text-slate-400">Indicador</span>
+          <div className="flex items-center gap-2 rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm">
+            <Filter className="h-4 w-4 text-slate-400" />
+            <select
+              value={selectedIndicator ?? ''}
+              onChange={event => setSelectedIndicator(event.target.value || null)}
+              className="w-full border-none bg-transparent text-sm focus:outline-none"
+              disabled={!indicatorsByArea.length}
+            >
+              {indicatorsByArea.map(indicator => (
+                <option key={indicator.id} value={indicator.id}>
+                  {indicator.nombre}
+                </option>
+              ))}
+            </select>
+          </div>
+          {!indicatorsByArea.length && (
+            <p className="text-xs text-slate-400">No hay indicadores registrados para el área seleccionada.</p>
+          )}
+        </label>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-[360px,1fr]">
+        <div className="space-y-4">
+          <section className="rounded-2xl bg-white p-6 shadow">
+            <p className="text-xs uppercase tracking-widest text-slate-400">Área seleccionada</p>
+            <h2 className="mt-2 text-lg font-semibold text-slate-800">
+              {areaOptions.find(area => area.id === selectedArea)?.name ?? 'Seleccione un área'}
+            </h2>
+            {activeIndicator?.area_estructura && (
+              <p className="mt-3 text-sm text-slate-500">{activeIndicator.area_estructura}</p>
+            )}
+          </section>
+
+          <section className="rounded-2xl bg-white p-6 shadow">
+            <p className="text-xs uppercase tracking-widest text-slate-400">Indicador</p>
+            <h2 className="mt-2 text-lg font-semibold text-slate-800">
+              {activeIndicator?.nombre ?? 'Seleccione un indicador'}
+            </h2>
+            {activeIndicator?.descripcion && (
+              <p className="mt-3 text-sm text-slate-500">{activeIndicator.descripcion}</p>
+            )}
+            <div className="mt-4 grid gap-3 text-sm text-slate-500">
+              <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3">
+                <p className="text-[11px] uppercase tracking-[0.35em] text-slate-400">Unidad</p>
+                <p className="mt-1 text-base font-semibold text-slate-800">
+                  {activeIndicator?.unidad_medida ?? 'No definida'}
+                </p>
+              </div>
+              <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3">
+                <p className="text-[11px] uppercase tracking-[0.35em] text-slate-400">Meta vigente</p>
+                <p className="mt-1 text-base font-semibold text-slate-800">
+                  {formatNumber(activeIndicator?.meta_vigente_valor)}
+                </p>
+                <p className="text-xs text-slate-500">Escenario {activeIndicator?.meta_vigente_escenario ?? '—'}</p>
+              </div>
+            </div>
+          </section>
+        </div>
+
+        <section className="space-y-6 rounded-2xl bg-white p-6 shadow">
+          <div className="flex items-center justify-between">
+            <h3 className="text-sm font-semibold uppercase tracking-widest text-slate-400">Tendencia histórica</h3>
+            {historyQuery.isFetching && <span className="text-xs text-slate-400">Actualizando datos...</span>}
+          </div>
+          <IndicatorHistoryChart history={historyQuery.data ?? []} targets={targetsQuery.data ?? []} />
+          <div className="overflow-hidden rounded-xl border border-slate-100">
+            <table className="min-w-full divide-y divide-slate-200 text-sm">
+              <thead className="bg-slate-50 text-xs uppercase tracking-widest text-slate-500">
+                <tr>
+                  <th className="px-4 py-2 text-left">Periodo</th>
+                  <th className="px-4 py-2 text-right">Valor</th>
+                  <th className="px-4 py-2 text-right">Escenario</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100">
+                {(historyQuery.data ?? []).map(item => (
+                  <tr key={item.id ?? `${item.anio}-${item.mes}`}> 
+                    <td className="px-4 py-2 text-slate-600">{formatMonth(item.anio, item.mes ?? 1)}</td>
+                    <td className="px-4 py-2 text-right font-medium text-slate-800">{
+                      formatNumber(
+                        item.valor ??
+                          item.valor_medido ??
+                          item.valor_real ??
+                          item.valor_actual ??
+                          item.cantidad
+                      )
+                    }</td>
+                    <td className="px-4 py-2 text-right text-slate-500">{item.escenario ?? '—'}</td>
+                  </tr>
+                ))}
+                {!historyQuery.data?.length && (
+                  <tr>
+                    <td colSpan={3} className="px-4 py-8 text-center text-slate-400">
+                      No hay registros históricos para este indicador.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/router.js
+++ b/src/router.js
@@ -1,8 +1,10 @@
 import { renderDashboard } from './views/dashboard.js';
 import { renderIndicators } from './views/indicators.js';
 import { renderCapture } from './views/capture.js';
+import { renderVisualization } from './views/visualization.js';
+import { renderUsers } from './views/users.js';
 import { renderLogin } from './views/login.js';
-import { getSession, subscribe } from './state/session.js';
+import { getSession, setSession, subscribe } from './state/session.js';
 import { renderLayout, highlightActiveRoute } from './ui/layout.js';
 import { signOut } from './services/supabaseClient.js';
 import { showToast } from './ui/feedback.js';
@@ -10,8 +12,10 @@ import { showToast } from './ui/feedback.js';
 const routes = {
   login: renderLogin,
   dashboard: renderDashboard,
+  visualizacion: renderVisualization,
   indicators: renderIndicators,
-  capture: renderCapture
+  capture: renderCapture,
+  users: renderUsers
 };
 
 function getRouteFromHash() {
@@ -40,9 +44,22 @@ function bindLayoutActions() {
       } catch (error) {
         console.error(error);
       }
-      localStorage.clear();
+      setSession(null);
       showToast('Sesión cerrada correctamente', { type: 'success' });
       window.location.hash = '#login';
+    });
+  }
+
+  const mobileMenu = document.getElementById('mobile-menu');
+  if (mobileMenu) {
+    const toggle = document.getElementById('mobile-menu-toggle');
+    mobileMenu.querySelectorAll('a[data-route]').forEach(link => {
+      link.addEventListener('click', () => {
+        mobileMenu.hidden = true;
+        if (toggle) {
+          toggle.setAttribute('aria-expanded', 'false');
+        }
+      });
     });
   }
 }

--- a/src/services/supabaseClient.js
+++ b/src/services/supabaseClient.js
@@ -12,6 +12,54 @@ export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
   }
 });
 
+function isRelationNotFound(error) {
+  return error?.code === '42P01' || /relation .+ does not exist/i.test(error?.message ?? '');
+}
+
+function isFunctionNotFound(error) {
+  return error?.code === '42883' || /function .+ does not exist/i.test(error?.message ?? '');
+}
+
+function normalizeStatus(value) {
+  const text = value?.toString().toLowerCase() ?? '';
+  return typeof text.normalize === 'function'
+    ? text.normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+    : text;
+}
+
+function normalizeMeasurement(record) {
+  if (!record) return record;
+  return {
+    ...record,
+    escenario: record.escenario ? record.escenario.toUpperCase() : null,
+    fecha_captura: record.fecha_captura ?? record.creado_en ?? null,
+    fecha_actualizacion:
+      record.fecha_actualizacion ?? record.fecha_ultima_edicion ?? record.actualizado_en ?? null
+  };
+}
+
+function normalizeTarget(record) {
+  if (!record) return record;
+  return {
+    ...record,
+    escenario: record.escenario ? record.escenario.toUpperCase() : null,
+    fecha_captura: record.fecha_captura ?? record.creado_en ?? null,
+    fecha_actualizacion:
+      record.fecha_actualizacion ?? record.fecha_ultima_edicion ?? record.actualizado_en ?? null
+  };
+}
+
+function sanitizeScenario(payload) {
+  if (!payload) return payload;
+  if ('escenario' in payload && payload.escenario) {
+    return { ...payload, escenario: payload.escenario.toUpperCase() };
+  }
+  if ('escenario' in payload) {
+    return { ...payload, escenario: null };
+  }
+  return payload;
+}
+
 export async function signInWithEmail({ email, password }) {
   const { error } = await supabase.auth.signInWithPassword({ email, password });
   if (error) throw error;
@@ -24,45 +72,195 @@ export async function signOut() {
 }
 
 export async function getDashboardSummary() {
-  const { data, error } = await supabase.from('v_dashboard_resumen').select('*');
-  if (error) throw error;
-  return data ?? [];
+  const relations = [
+    'v_dashboard_resumen',
+    'v_dashboard_resumen_v2',
+    'vw_dashboard_resumen',
+    'vw_dashboard_resumen_v2',
+    'dashboard_resumen',
+    'dashboard_resumen_view',
+    'dashboard_resumen_vista',
+    'dashboard_resumen_general',
+    'resumen_dashboard',
+    'vista_dashboard_resumen',
+    'vista_dashboard_resumen_v2'
+  ];
+
+  for (const relation of relations) {
+    const { data, error } = await supabase.from(relation).select('*');
+
+    if (!error) {
+      return data ?? [];
+    }
+
+    if (!isRelationNotFound(error)) {
+      throw error;
+    }
+  }
+
+  return [];
 }
 
 export async function getDirectorsHighlights() {
+  const highlightRelations = [
+    'v_indicadores_criticos',
+    'v_indicadores_prioritarios',
+    'vw_indicadores_criticos',
+    'vw_indicadores_prioritarios',
+    'vw_indicadores_alertas',
+    'vw_indicadores_alerta',
+    'indicadores_criticos',
+    'indicadores_prioritarios',
+    'indicadores_alertas',
+    'indicadores_directivos_resumen',
+    'resumen_indicadores_directivos',
+    'resumen_indicadores_prioritarios',
+    'vista_indicadores_criticos',
+    'vista_indicadores_prioritarios'
+  ];
+
+  for (const relation of highlightRelations) {
+    const { data, error } = await supabase.from(relation).select('*');
+
+    if (!error) {
+      return data ?? [];
+    }
+
+    if (!isRelationNotFound(error)) {
+      throw error;
+    }
+  }
+
+  const indicatorRelations = [
+    'v_indicadores_area',
+    'v_indicadores',
+    'vw_indicadores_area',
+    'vw_indicadores_detalle',
+    'vw_indicadores',
+    'indicadores_area',
+    'indicadores',
+    'vista_indicadores_area',
+    'vista_indicadores'
+  ];
+
+  for (const relation of indicatorRelations) {
+    const { data: indicators, error } = await supabase.from(relation).select('*');
+
+    if (error) {
+      if (isRelationNotFound(error)) {
+        continue;
+      }
+      throw error;
+    }
+
+    if (indicators?.length) {
+      const criticalIndicators = indicators.filter(record => {
+        if (record == null || typeof record !== 'object') return false;
+        if ('es_critico' in record) return Boolean(record.es_critico);
+        if ('es_alerta' in record) return Boolean(record.es_alerta);
+        if ('critico' in record) return Boolean(record.critico);
+        if ('alerta' in record) return Boolean(record.alerta);
+        const status =
+          record.nivel_alerta ??
+          record.estatus ??
+          record.estado ??
+          record.estatus_alerta ??
+          record.color_alerta ??
+          '';
+        return ['critico', 'alerta', 'rojo'].includes(normalizeStatus(status));
+      });
+
+      if (criticalIndicators.length) {
+        return criticalIndicators.map(item => ({
+          ...item,
+          valor_actual: item.valor_actual ?? item.ultima_medicion_valor ?? item.valor ?? null,
+          meta: item.meta ?? item.valor_meta ?? item.meta_actual ?? null,
+          actualizado_en: item.actualizado_en ?? item.fecha_actualizacion ?? item.ultima_medicion_fecha ?? null,
+          area: item.area ?? item.area_nombre ?? null
+        }));
+      }
+    }
+  }
+
   const { data, error } = await supabase.rpc('kpi_resumen_directivos');
-  if (error) throw error;
+  if (error) {
+    if (isFunctionNotFound(error)) return [];
+    throw error;
+  }
   return data ?? [];
 }
 
 export async function getIndicators() {
-  const { data, error } = await supabase
-    .from('v_indicadores_area')
-    .select('*')
-    .order('area_nombre', { ascending: true })
-    .order('nombre', { ascending: true });
-  if (error) throw error;
-  return data ?? [];
+  const relations = [
+    'v_indicadores_area',
+    'v_indicadores',
+    'vw_indicadores_area',
+    'vw_indicadores_detalle',
+    'vw_indicadores',
+    'indicadores_area',
+    'indicadores',
+    'vista_indicadores_area',
+    'vista_indicadores'
+  ];
+
+  for (const relation of relations) {
+    const { data, error } = await supabase
+      .from(relation)
+      .select('*')
+      .order('area_nombre', { ascending: true })
+      .order('nombre', { ascending: true });
+
+    if (!error) {
+      return data ?? [];
+    }
+
+    if (!isRelationNotFound(error)) {
+      throw error;
+    }
+  }
+
+  return [];
 }
 
 export async function getIndicatorHistory(indicadorId, { limit = 24 } = {}) {
-  const query = supabase
-    .from('mediciones')
-    .select('id, indicador_id, periodo, anio, mes, valor, escenario, creado_en')
-    .eq('indicador_id', indicadorId)
-    .order('anio', { ascending: true })
-    .order('mes', { ascending: true })
-    .limit(limit);
+  if (!indicadorId) return [];
 
-  const { data, error } = await query;
-  if (error) throw error;
-  return data ?? [];
+  const relations = [
+    'v_mediciones_historico',
+    'v_mediciones_historico_v2',
+    'mediciones_historico',
+    'mediciones_historico_view',
+    'vista_mediciones_historico',
+    'vw_mediciones_historico',
+    'mediciones'
+  ];
+
+  for (const relation of relations) {
+    const { data, error } = await supabase
+      .from(relation)
+      .select('*')
+      .eq('indicador_id', indicadorId)
+      .order('anio', { ascending: true })
+      .order('mes', { ascending: true })
+      .limit(limit);
+
+    if (!error) {
+      return (data ?? []).map(normalizeMeasurement);
+    }
+
+    if (!isRelationNotFound(error)) {
+      throw error;
+    }
+  }
+
+  return [];
 }
 
 export async function getIndicatorTargets(indicadorId, { year } = {}) {
+  if (!indicadorId) return [];
   let query = supabase
     .from('indicador_metas')
-    .select('id, indicador_id, anio, mes, escenario, valor, fecha_captura, fecha_ultima_edicion')
+    .select('*')
     .eq('indicador_id', indicadorId)
     .order('anio', { ascending: true })
     .order('mes', { ascending: true });
@@ -73,32 +271,81 @@ export async function getIndicatorTargets(indicadorId, { year } = {}) {
 
   const { data, error } = await query;
   if (error) throw error;
-  return data ?? [];
+  return (data ?? []).map(normalizeTarget);
 }
 
 export async function saveMeasurement(payload) {
-  const { data, error } = await supabase.from('mediciones').insert(payload).select().single();
+  const sanitized = sanitizeScenario(payload);
+  const { data, error } = await supabase.from('mediciones').insert(sanitized).select().single();
   if (error) throw error;
-  return data;
+  return normalizeMeasurement(data);
 }
 
 export async function updateMeasurement(id, payload) {
+  const sanitized = sanitizeScenario(payload);
   const { data, error } = await supabase
     .from('mediciones')
-    .update(payload)
+    .update(sanitized)
     .eq('id', id)
     .select()
     .single();
   if (error) throw error;
-  return data;
+  return normalizeMeasurement(data);
 }
 
 export async function upsertTarget(payload) {
+  const sanitized = sanitizeScenario(payload);
   const { data, error } = await supabase
     .from('indicador_metas')
-    .upsert(payload, { onConflict: 'indicador_id,anio,mes,escenario' })
+    .upsert(sanitized, { onConflict: 'indicador_id,anio,mes,escenario' })
     .select()
     .single();
   if (error) throw error;
-  return data;
+  return normalizeTarget(data);
+}
+
+function normalizeUser(record) {
+  if (!record) return null;
+  const email = record.email ?? record.correo ?? record.usuario?.email ?? record.usuario_email ?? null;
+  const lastAccess =
+    record.ultimo_acceso ?? record.ultima_conexion ?? record.ultimo_login ?? record.actualizado_en ?? null;
+  return {
+    id:
+      record.id ??
+      record.usuario_id ??
+      email ??
+      record.nombre_completo ??
+      record.nombre ??
+      `usuario-${Math.random().toString(36).slice(2)}`,
+    nombre: record.nombre_completo ?? record.nombre ?? record.full_name ?? 'Sin nombre',
+    puesto: record.puesto ?? record.cargo ?? null,
+    rol: record.rol ?? record.perfil ?? record.tipo ?? null,
+    email: email ?? '—',
+    direccion: record.direccion ?? record.area ?? record.area_nombre ?? record.subdireccion ?? null,
+    ultimo_acceso: lastAccess
+  };
+}
+
+export async function getUsers() {
+  const relationCandidates = [
+    { relation: 'v_usuarios_sistema', select: 'id,nombre_completo,nombre,puesto,rol,correo,email,direccion,subdireccion,ultima_conexion,ultimo_acceso,usuario:usuarios(email,ultimo_acceso)' },
+    { relation: 'vw_usuarios', select: 'id,nombre_completo,nombre,puesto,rol,correo,email,direccion,ultima_conexion' },
+    { relation: 'usuarios_detalle', select: 'id,nombre_completo,nombre,puesto,rol,correo,email,direccion,ultima_conexion' },
+    { relation: 'usuarios', select: 'id,nombre,correo,rol,ultimo_acceso' },
+    { relation: 'perfiles', select: 'id,nombre_completo,nombre,puesto,rol,usuario:usuarios(email,ultimo_acceso)' }
+  ];
+
+  for (const candidate of relationCandidates) {
+    const { data, error } = await supabase.from(candidate.relation).select(candidate.select);
+
+    if (!error) {
+      return (data ?? []).map(normalizeUser).filter(Boolean);
+    }
+
+    if (!isRelationNotFound(error)) {
+      throw error;
+    }
+  }
+
+  return [];
 }

--- a/src/ui/layout.js
+++ b/src/ui/layout.js
@@ -2,92 +2,87 @@ import { getSession } from '../state/session.js';
 
 const NAV_ITEMS = [
   { id: 'dashboard', label: 'Panel Directivos', icon: 'fa-chart-line' },
+  { id: 'visualizacion', label: 'Visualización de Indicadores', icon: 'fa-chart-area' },
   { id: 'indicators', label: 'Consulta de Indicadores', icon: 'fa-table' },
-  { id: 'capture', label: 'Captura de Indicadores', icon: 'fa-pen-to-square' }
+  { id: 'capture', label: 'Captura de Indicadores', icon: 'fa-pen-to-square' },
+  { id: 'users', label: 'Administración de Usuarios', icon: 'fa-users-gear' }
 ];
 
 export function renderLayout(content) {
   const user = getSession();
   return `
-    <div class="min-h-screen bg-gradient-to-br from-slate-100 via-white to-slate-100">
-      <div class="mx-auto flex min-h-screen max-w-7xl flex-col lg:flex-row">
-        <aside class="hidden w-full max-w-xs flex-col rounded-3xl bg-white/95 p-6 text-slate-600 shadow-xl shadow-slate-900/5 backdrop-blur lg:flex">
-          <div class="flex items-center gap-3 border-b border-slate-200 pb-5">
-            <img src="./assets/logo-aifa.svg" alt="Logotipo AIFA" class="h-12 w-auto" />
-            <div>
-              <p class="text-[11px] uppercase tracking-[0.35em] text-slate-400">Indicadores</p>
-              <p class="text-base font-semibold text-slate-800">Panel AIFA</p>
+    <div class="min-h-screen bg-slate-100">
+      <header class="border-b border-slate-200 bg-white/95 shadow-sm backdrop-blur">
+        <div class="mx-auto flex h-20 w-full max-w-7xl items-center justify-between gap-6 px-4 sm:px-6 lg:px-8">
+          <div class="flex items-center gap-4">
+            <img src="./assets/AIFA_logo.png" alt="Logotipo AIFA" class="h-12 w-auto" />
+            <div class="hidden sm:block">
+              <p class="text-xs font-semibold uppercase tracking-[0.4em] text-primary-700">AIFA</p>
+              <h1 class="text-sm font-semibold text-slate-700">Sistema de Indicadores</h1>
             </div>
           </div>
-          <nav class="mt-6 flex-1 overflow-y-auto">
-            <ul class="space-y-1" id="main-menu">
-              ${NAV_ITEMS.map(
-                (item) => `
-                  <li>
-                    <a
-                      href="#${item.id}"
-                      data-route="${item.id}"
-                      class="flex items-center gap-3 rounded-2xl px-4 py-3 text-sm font-medium text-slate-500 transition hover:bg-slate-100 hover:text-slate-800"
-                    >
-                      <span class="flex h-9 w-9 items-center justify-center rounded-2xl bg-slate-100 text-slate-500">
-                        <i class="fa-solid ${item.icon}"></i>
-                      </span>
-                      <span>${item.label}</span>
-                    </a>
-                  </li>
-                `
-              ).join('')}
-            </ul>
+          <nav class="hidden items-center gap-2 lg:flex" id="main-menu">
+            ${NAV_ITEMS.map(
+              item => `
+                <a
+                  href="#${item.id}"
+                  data-route="${item.id}"
+                  class="inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-medium text-slate-600 transition hover:bg-slate-100 hover:text-slate-900"
+                >
+                  <span class="flex h-8 w-8 items-center justify-center rounded-full bg-slate-100 text-slate-500">
+                    <i class="fa-solid ${item.icon}"></i>
+                  </span>
+                  ${item.label}
+                </a>
+              `
+            ).join('')}
           </nav>
-          <div class="rounded-2xl border border-slate-200 bg-slate-50/80 p-4 text-sm">
-            <p class="font-semibold text-slate-700">${user?.user?.email ?? 'Sesión no iniciada'}</p>
-            <p class="mt-1 text-xs text-slate-400">Dirección Estratégica</p>
+          <div class="flex items-center gap-3">
+            <div class="hidden text-right text-xs sm:block">
+              <p class="font-semibold text-slate-800">${user?.user?.email ?? 'Sesión no iniciada'}</p>
+              <p class="text-[11px] uppercase tracking-[0.4em] text-slate-400">${user?.rol ?? 'AIFA'}</p>
+            </div>
             <button
               id="sign-out"
-              class="mt-4 inline-flex items-center gap-2 rounded-xl bg-primary-600 px-3 py-2 text-xs font-semibold text-white shadow-sm shadow-primary-500/30 transition hover:bg-primary-700"
+              class="inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-1.5 text-sm font-medium text-slate-600 transition hover:border-primary-500 hover:text-primary-600"
             >
               <i class="fa-solid fa-arrow-right-from-bracket"></i>
-              Cerrar sesión
+              <span class="hidden sm:inline">Cerrar sesión</span>
+            </button>
+            <button
+              id="mobile-menu-toggle"
+              class="rounded-full border border-slate-200 p-2 text-slate-600 transition hover:border-primary-500 hover:text-primary-600 lg:hidden"
+              aria-label="Abrir menú"
+            >
+              <i class="fa-solid fa-bars"></i>
             </button>
           </div>
-        </aside>
-        <main class="flex-1 py-10 lg:pl-10">
-          <div class="mx-auto flex h-full w-full max-w-4xl flex-col rounded-[32px] border border-slate-200/70 bg-white/95 shadow-xl shadow-slate-900/5 backdrop-blur">
-            <header class="flex flex-col gap-5 border-b border-slate-200 px-6 py-6 text-slate-600 sm:flex-row sm:items-center sm:justify-between">
-              <div class="flex items-center gap-4">
-                <img src="./assets/logo-aifa.svg" alt="Logotipo AIFA" class="h-12 w-auto" />
-                <div>
-                  <p class="text-xs uppercase tracking-[0.4em] text-slate-400">Sistema de Indicadores</p>
-                  <h1 class="text-lg font-semibold text-slate-800">Aeropuerto Internacional Felipe Ángeles</h1>
-                </div>
-              </div>
-              <div class="flex flex-col items-start gap-4 sm:items-end">
-                <span class="inline-flex items-center gap-2 rounded-full bg-primary-50 px-4 py-2 text-xs font-semibold text-primary-700">
-                  <i class="fa-solid fa-gauge-high"></i>
-                  Gestión Estratégica
-                </span>
-                <div class="flex flex-wrap gap-2 sm:hidden" id="mobile-menu">
-                  ${NAV_ITEMS.map(
-                    (item) => `
-                      <a
-                        href="#${item.id}"
-                        data-route="${item.id}"
-                        class="inline-flex items-center gap-2 rounded-full border border-slate-200 px-4 py-2 text-xs font-semibold text-slate-500"
-                      >
-                        <i class="fa-solid ${item.icon}"></i>
-                        ${item.label}
-                      </a>
-                    `
-                  ).join('')}
-                </div>
-              </div>
-            </header>
-            <div class="flex-1 overflow-y-auto px-6 py-8" id="content">
-              ${content}
-            </div>
-          </div>
-        </main>
-      </div>
+        </div>
+        <div class="border-t border-slate-200 bg-white px-4 py-3 shadow-inner lg:hidden" id="mobile-menu" hidden>
+          <nav class="flex flex-col gap-2">
+            ${NAV_ITEMS.map(
+              item => `
+                <a
+                  href="#${item.id}"
+                  data-route="${item.id}"
+                  class="flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-slate-600 transition hover:bg-slate-100 hover:text-slate-900"
+                >
+                  <span class="flex h-9 w-9 items-center justify-center rounded-full bg-slate-100 text-slate-500">
+                    <i class="fa-solid ${item.icon}"></i>
+                  </span>
+                  ${item.label}
+                </a>
+              `
+            ).join('')}
+          </nav>
+        </div>
+      </header>
+      <main class="mx-auto w-full max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+        <div class="mb-6 text-sm uppercase tracking-[0.4em] text-slate-400" id="active-section">Panel Directivos</div>
+        <div class="min-h-[60vh] rounded-[32px] border border-slate-200/70 bg-white/95 p-6 shadow-xl shadow-slate-900/5 backdrop-blur" id="content">
+          ${content}
+        </div>
+      </main>
     </div>
   `;
 }
@@ -95,33 +90,55 @@ export function renderLayout(content) {
 export function highlightActiveRoute(routeId) {
   const desktopLinks = document.querySelectorAll('#main-menu a[data-route]');
   const mobileLinks = document.querySelectorAll('#mobile-menu a[data-route]');
+  const activeLabel = NAV_ITEMS.find(item => item.id === routeId)?.label ?? 'Panel Directivos';
+  const sectionLabel = document.getElementById('active-section');
 
-  desktopLinks.forEach((link) => {
-    const icon = link.querySelector('span');
+  if (sectionLabel) {
+    sectionLabel.textContent = activeLabel;
+  }
+
+  desktopLinks.forEach(link => {
+    const iconWrapper = link.querySelector('span');
     if (link.dataset.route === routeId) {
       link.classList.add('bg-primary-600', 'text-white', 'shadow-lg', 'shadow-primary-500/30');
-      link.classList.remove('text-slate-500');
-      if (icon) {
-        icon.classList.remove('bg-slate-100', 'text-slate-500');
-        icon.classList.add('bg-white/20', 'text-white');
+      link.classList.remove('text-slate-600');
+      if (iconWrapper) {
+        iconWrapper.classList.remove('bg-slate-100', 'text-slate-500');
+        iconWrapper.classList.add('bg-white/20', 'text-white');
       }
     } else {
       link.classList.remove('bg-primary-600', 'text-white', 'shadow-lg', 'shadow-primary-500/30');
-      link.classList.add('text-slate-500');
-      if (icon) {
-        icon.classList.add('bg-slate-100', 'text-slate-500');
-        icon.classList.remove('bg-white/20', 'text-white');
+      link.classList.add('text-slate-600');
+      if (iconWrapper) {
+        iconWrapper.classList.add('bg-slate-100', 'text-slate-500');
+        iconWrapper.classList.remove('bg-white/20', 'text-white');
       }
     }
   });
 
-  mobileLinks.forEach((link) => {
+  mobileLinks.forEach(link => {
     if (link.dataset.route === routeId) {
-      link.classList.add('border-transparent', 'bg-primary-600', 'text-white', 'shadow');
-      link.classList.remove('border-slate-200', 'text-slate-500');
+      link.classList.add('bg-primary-600', 'text-white', 'shadow');
+      link.classList.remove('text-slate-600');
     } else {
-      link.classList.remove('border-transparent', 'bg-primary-600', 'text-white', 'shadow');
-      link.classList.add('border-slate-200', 'text-slate-500');
+      link.classList.remove('bg-primary-600', 'text-white', 'shadow');
+      link.classList.add('text-slate-600');
     }
   });
+
+  const toggle = document.getElementById('mobile-menu-toggle');
+  const menu = document.getElementById('mobile-menu');
+  if (menu) {
+    menu.hidden = true;
+  }
+  if (toggle) {
+    toggle.setAttribute('aria-expanded', 'false');
+  }
+  if (toggle && menu && !toggle.dataset.bound) {
+    toggle.dataset.bound = 'true';
+    toggle.addEventListener('click', () => {
+      menu.hidden = !menu.hidden;
+      toggle.setAttribute('aria-expanded', String(!menu.hidden));
+    });
+  }
 }

--- a/src/views/capture.js
+++ b/src/views/capture.js
@@ -41,7 +41,7 @@ function buildHistoryTable(history) {
                   <td class="px-4 py-3 text-slate-600">${monthName(item.mes)} ${item.anio}</td>
                   <td class="px-4 py-3 text-right font-semibold text-slate-800">${formatNumber(item.valor)}</td>
                   <td class="px-4 py-3 text-slate-500">${item.escenario ?? '—'}</td>
-                  <td class="px-4 py-3 text-right text-slate-400 text-xs">${formatDate(item.creado_en)}</td>
+                  <td class="px-4 py-3 text-right text-slate-400 text-xs">${formatDate(item.fecha_captura ?? item.creado_en)}</td>
                 </tr>
               `;
             })
@@ -79,7 +79,7 @@ function buildTargetsTable(targets) {
                   <td class="px-4 py-3 text-slate-600">${monthName(item.mes)} ${item.anio}</td>
                   <td class="px-4 py-3 text-right font-semibold text-slate-800">${formatNumber(item.valor)}</td>
                   <td class="px-4 py-3 text-slate-500">${item.escenario ?? '—'}</td>
-                  <td class="px-4 py-3 text-right text-slate-400 text-xs">${formatDate(item.fecha_ultima_edicion)}</td>
+                  <td class="px-4 py-3 text-right text-slate-400 text-xs">${formatDate(item.fecha_actualizacion ?? item.fecha_ultima_edicion)}</td>
                 </tr>
               `;
             })
@@ -148,10 +148,10 @@ export async function renderCapture(container) {
                   <label class="flex flex-col gap-1 text-sm text-slate-600">
                     Escenario
                     <select name="scenario" class="rounded-lg border border-slate-200 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-slate-400">
-                      <option value="real">Real</option>
-                      <option value="bajo">Bajo</option>
-                      <option value="medio">Medio</option>
-                      <option value="alto">Alto</option>
+                      <option value="REAL">Real</option>
+                      <option value="BAJO">Bajo</option>
+                      <option value="MEDIO">Medio</option>
+                      <option value="ALTO">Alto</option>
                     </select>
                   </label>
                 </div>
@@ -190,9 +190,9 @@ export async function renderCapture(container) {
                   <label class="flex flex-col gap-1 text-sm text-slate-600">
                     Escenario
                     <select name="scenario" class="rounded-lg border border-slate-200 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-slate-400">
-                      <option value="bajo">Bajo</option>
-                      <option value="medio">Medio</option>
-                      <option value="alto">Alto</option>
+                      <option value="BAJO">Bajo</option>
+                      <option value="MEDIO">Medio</option>
+                      <option value="ALTO">Alto</option>
                     </select>
                   </label>
                 </div>
@@ -264,14 +264,14 @@ export async function renderCapture(container) {
       submit.disabled = true;
       submit.classList.add('opacity-70');
       const formData = new FormData(form);
-      const scenario = formData.get('scenario');
+      const scenario = (formData.get('scenario') ?? '').toString().toUpperCase();
 
       const payload = {
         indicador_id: state.indicatorId,
         anio: state.year,
         mes: Number(formData.get('month')),
         valor: Number(formData.get('value')),
-        escenario: scenario === 'real' ? null : scenario
+        escenario: scenario || null
       };
 
       try {
@@ -300,7 +300,7 @@ export async function renderCapture(container) {
         indicador_id: state.indicatorId,
         anio: state.year,
         mes: Number(formData.get('month')),
-        escenario: formData.get('scenario'),
+        escenario: (formData.get('scenario') ?? '').toString().toUpperCase(),
         valor: Number(formData.get('value'))
       };
 

--- a/src/views/dashboard.js
+++ b/src/views/dashboard.js
@@ -1,22 +1,121 @@
 import {
   getDashboardSummary,
-  getDirectorsHighlights,
   getIndicators,
   getIndicatorHistory,
   getIndicatorTargets
 } from '../services/supabaseClient.js';
-import { formatNumber, formatPercentage, formatDate } from '../utils/formatters.js';
+import { formatNumber, formatPercentage, formatDate, monthName } from '../utils/formatters.js';
 import { renderLoading, renderError, showToast } from '../ui/feedback.js';
 import { renderIndicatorChart } from '../ui/charts.js';
+import {
+  INDICATOR_SECTIONS,
+  DIRECTION_FALLBACKS,
+  buildIndicatorOptions,
+  normalizeText,
+  buildCodeFromName
+} from '../config/dashboardConfig.js';
 
-const OPERATIVE_NAMES = [
-  'Aviación Comercial Pasajeros',
-  'Aviación Comercial Operaciones',
-  'Aviación Carga Operaciones',
-  'Aviación Carga Toneladas'
-];
+const PALETTES = {
+  indigo: {
+    border: 'border-indigo-100',
+    background: 'bg-indigo-50/80',
+    icon: 'text-indigo-500',
+    badge: 'bg-indigo-100 text-indigo-700',
+    optionIdle: 'border-indigo-100 hover:border-indigo-200 hover:bg-white',
+    optionActive: 'border-indigo-200 bg-white shadow-lg shadow-indigo-200/60 text-indigo-900',
+    chevron: 'text-indigo-500'
+  },
+  blue: {
+    border: 'border-blue-100',
+    background: 'bg-blue-50/80',
+    icon: 'text-blue-500',
+    badge: 'bg-blue-100 text-blue-700',
+    optionIdle: 'border-blue-100 hover:border-blue-200 hover:bg-white',
+    optionActive: 'border-blue-200 bg-white shadow-lg shadow-blue-200/60 text-blue-900',
+    chevron: 'text-blue-500'
+  },
+  amber: {
+    border: 'border-amber-100',
+    background: 'bg-amber-50/80',
+    icon: 'text-amber-500',
+    badge: 'bg-amber-100 text-amber-700',
+    optionIdle: 'border-amber-100 hover:border-amber-200 hover:bg-white',
+    optionActive: 'border-amber-200 bg-white shadow-lg shadow-amber-200/60 text-amber-900',
+    chevron: 'text-amber-500'
+  },
+  orange: {
+    border: 'border-orange-100',
+    background: 'bg-orange-50/80',
+    icon: 'text-orange-500',
+    badge: 'bg-orange-100 text-orange-700',
+    optionIdle: 'border-orange-100 hover:border-orange-200 hover:bg-white',
+    optionActive: 'border-orange-200 bg-white shadow-lg shadow-orange-200/60 text-orange-900',
+    chevron: 'text-orange-500'
+  },
+  emerald: {
+    border: 'border-emerald-100',
+    background: 'bg-emerald-50/80',
+    icon: 'text-emerald-500',
+    badge: 'bg-emerald-100 text-emerald-700',
+    optionIdle: 'border-emerald-100 hover:border-emerald-200 hover:bg-white',
+    optionActive: 'border-emerald-200 bg-white shadow-lg shadow-emerald-200/60 text-emerald-900',
+    chevron: 'text-emerald-500'
+  },
+  teal: {
+    border: 'border-teal-100',
+    background: 'bg-teal-50/80',
+    icon: 'text-teal-500',
+    badge: 'bg-teal-100 text-teal-700',
+    optionIdle: 'border-teal-100 hover:border-teal-200 hover:bg-white',
+    optionActive: 'border-teal-200 bg-white shadow-lg shadow-teal-200/60 text-teal-900',
+    chevron: 'text-teal-500'
+  },
+  violet: {
+    border: 'border-violet-100',
+    background: 'bg-violet-50/80',
+    icon: 'text-violet-500',
+    badge: 'bg-violet-100 text-violet-700',
+    optionIdle: 'border-violet-100 hover:border-violet-200 hover:bg-white',
+    optionActive: 'border-violet-200 bg-white shadow-lg shadow-violet-200/60 text-violet-900',
+    chevron: 'text-violet-500'
+  },
+  sky: {
+    border: 'border-sky-100',
+    background: 'bg-sky-50/80',
+    icon: 'text-sky-500',
+    badge: 'bg-sky-100 text-sky-700',
+    optionIdle: 'border-sky-100 hover:border-sky-200 hover:bg-white',
+    optionActive: 'border-sky-200 bg-white shadow-lg shadow-sky-200/60 text-sky-900',
+    chevron: 'text-sky-500'
+  },
+  slate: {
+    border: 'border-slate-200',
+    background: 'bg-slate-50/80',
+    icon: 'text-slate-500',
+    badge: 'bg-slate-100 text-slate-600',
+    optionIdle: 'border-slate-200 hover:border-slate-300 hover:bg-white',
+    optionActive: 'border-slate-300 bg-white shadow-lg shadow-slate-200/60 text-slate-900',
+    chevron: 'text-slate-500'
+  }
+};
 
-const FBO_NAMES = ['Aviación General Pasajeros', 'Aviación General Operaciones'];
+const CARD_ICON_CLASSES = {
+  'plane-operations': 'fa-solid fa-plane-up',
+  'plane-passengers': 'fa-solid fa-users-between-lines',
+  'cargo-operations': 'fa-solid fa-boxes-stacked',
+  'cargo-weight': 'fa-solid fa-weight-hanging',
+  'fbo-operations': 'fa-solid fa-plane',
+  'fbo-passengers': 'fa-solid fa-user-group'
+};
+
+const OPTION_ICON_CLASSES = {
+  'calendar-month': 'fa-solid fa-calendar-days',
+  'calendar-quarter': 'fa-solid fa-calendar-week',
+  'calendar-year': 'fa-solid fa-calendar',
+  'target-low': 'fa-solid fa-bullseye',
+  'target-mid': 'fa-solid fa-chart-line',
+  'target-high': 'fa-solid fa-bullseye-pointer'
+};
 
 function buildSummaryCards(summary) {
   if (!summary?.length) {
@@ -28,20 +127,29 @@ function buildSummaryCards(summary) {
     { key: 'indicadores_con_metas', label: 'Indicadores con metas' },
     { key: 'indicadores_sin_actualizar', label: 'Indicadores pendientes' },
     { key: 'porcentaje_cumplimiento', label: 'Cumplimiento promedio', type: 'percentage' }
-  ].filter((field) => field.key in data);
+  ].filter(field => field.key in data);
+
+  if (!fields.length) {
+    return '<p class="text-sm text-slate-500">No hay métricas para mostrar.</p>';
+  }
 
   return `
     <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
       ${fields
-        .map((field) => {
+        .map(field => {
           const value = data[field.key];
           const formatted =
-            field.type === 'percentage' ? formatPercentage(value) : formatNumber(value, { decimals: 0 });
+            field.type === 'percentage'
+              ? formatPercentage(value)
+              : formatNumber(value, { decimals: 0 });
           return `
-            <div class="rounded-2xl bg-white p-6 shadow border border-slate-100">
-              <p class="text-xs uppercase tracking-widest text-slate-400">${field.label}</p>
-              <p class="mt-3 text-3xl font-semibold text-slate-800">${formatted}</p>
-            </div>
+            <article class="relative overflow-hidden rounded-2xl border border-slate-100 bg-white p-6 shadow transition hover:shadow-lg">
+              <div class="absolute -top-10 -right-10 h-32 w-32 rounded-full bg-aifa-light/10"></div>
+              <div class="relative">
+                <p class="text-xs uppercase tracking-widest text-slate-400">${field.label}</p>
+                <p class="mt-3 text-3xl font-semibold text-slate-800">${formatted}</p>
+              </div>
+            </article>
           `;
         })
         .join('')}
@@ -49,201 +157,625 @@ function buildSummaryCards(summary) {
   `;
 }
 
-function buildHighlightsTable(highlights) {
-  if (!highlights?.length) {
+function buildIndicatorCard(category, options) {
+  const palette = PALETTES[category.palette] ?? PALETTES.slate;
+  const iconClass = CARD_ICON_CLASSES[category.icon] ?? 'fa-solid fa-chart-line';
+  const assignedCount = options.filter(option => option.indicator).length;
+  const headerStatus = assignedCount
+    ? `${assignedCount} opción${assignedCount === 1 ? '' : 'es'} asignada${assignedCount === 1 ? '' : 's'}`
+    : 'Sin asignar';
+
+  return `
+    <article class="overflow-hidden rounded-2xl border ${palette.border} bg-white shadow-sm" data-card="${category.id}">
+      <button
+        type="button"
+        class="flex w-full items-center justify-between gap-4 px-5 py-4 text-left transition ${palette.background} focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-aifa-light"
+        data-toggle-card="${category.id}"
+        aria-expanded="false"
+      >
+        <div class="flex flex-1 items-center gap-3">
+          <span class="flex h-11 w-11 items-center justify-center rounded-full bg-white shadow ${palette.icon}">
+            <i class="${iconClass}"></i>
+          </span>
+          <div>
+            <p class="text-base font-semibold text-slate-800">${category.label}</p>
+            <span class="inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-widest ${palette.badge}">
+              ${headerStatus}
+            </span>
+          </div>
+        </div>
+        <i class="fa-solid fa-chevron-down transition-transform ${palette.chevron}" data-chevron="${category.id}"></i>
+      </button>
+      <div class="grid transition-[grid-template-rows] duration-300 ease-in-out grid-rows-[0fr]" data-card-body="${category.id}">
+        <div class="min-h-0 overflow-hidden border-t border-slate-100 bg-white px-5 py-4">
+          <div class="flex flex-col gap-3">
+            ${options
+              .map(option => {
+                const enabled = Boolean(option.indicator);
+                const optionIcon = OPTION_ICON_CLASSES[option.icon] ?? 'fa-solid fa-chart-line';
+                const idle = palette.optionIdle;
+                const active = palette.optionActive;
+                return `
+                  <button
+                    type="button"
+                    class="flex w-full items-start gap-3 rounded-xl border px-4 py-3 text-left text-sm transition focus:outline-none focus:ring-2 focus:ring-offset-2 ${
+                      enabled ? `${idle} focus:ring-aifa-light` : 'border-dashed border-slate-200 bg-white/60 text-slate-400 cursor-not-allowed focus:ring-slate-200'
+                    }"
+                    data-option="${option.id}"
+                    data-theme-idle="${idle}"
+                    data-theme-active="${active}"
+                    data-card-owner="${category.id}"
+                    data-enabled="${enabled ? 'true' : 'false'}"
+                    data-indicator-id="${option.indicator?.id ?? ''}"
+                  >
+                    <span class="flex h-10 w-10 items-center justify-center rounded-full bg-white shadow-sm ${
+                      enabled ? palette.icon : 'text-slate-400'
+                    }">
+                      <i class="${optionIcon}"></i>
+                    </span>
+                    <div class="flex flex-1 flex-col gap-1">
+                      <span class="font-medium leading-snug">${option.label}</span>
+                      <span class="text-xs ${enabled ? 'text-slate-500' : 'text-slate-400'}">
+                        ${enabled
+                          ? `Último valor: ${formatNumber(option.indicator.ultima_medicion_valor)} ${option.indicator.unidad_medida ?? ''}`
+                          : 'Sin asignar'}
+                      </span>
+                    </div>
+                    ${
+                      option.indicator?.ultima_medicion_fecha
+                        ? `<div class="text-right text-xs text-slate-400">
+                            Actualizado<br />
+                            ${formatDate(option.indicator.ultima_medicion_fecha)}
+                          </div>`
+                        : ''
+                    }
+                  </button>
+                `;
+              })
+              .join('')}
+          </div>
+        </div>
+      </div>
+    </article>
+  `;
+}
+
+function buildDirectionCard(direction) {
+  const palette = PALETTES[direction.palette] ?? PALETTES.slate;
+  return `
+    <article class="overflow-hidden rounded-2xl border ${palette.border} bg-white shadow-sm" data-direction="${direction.id}">
+      <button
+        type="button"
+        class="flex w-full items-center justify-between gap-4 px-5 py-4 text-left transition ${palette.background} focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-aifa-light"
+        data-toggle-direction="${direction.id}"
+        aria-expanded="false"
+      >
+        <div class="flex flex-1 items-center gap-3">
+          <span class="flex h-11 w-11 items-center justify-center rounded-full bg-white shadow ${palette.icon}">
+            <i class="fa-solid fa-users"></i>
+          </span>
+          <div>
+            <p class="text-base font-semibold text-slate-800">${direction.name}</p>
+            <span class="inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-widest ${palette.badge}">
+              <span class="rounded-full bg-white/80 px-2 py-0.5 text-[10px] font-bold text-slate-700">${direction.code}</span>
+              ${direction.subdirections.length
+                ? `${direction.subdirections.length} subdirección${direction.subdirections.length === 1 ? '' : 'es'}`
+                : 'Sin subdirecciones registradas'}
+            </span>
+          </div>
+        </div>
+        <i class="fa-solid fa-chevron-down transition-transform ${palette.chevron}" data-direction-chevron="${direction.id}"></i>
+      </button>
+      <div class="grid transition-[grid-template-rows] duration-300 ease-in-out grid-rows-[0fr]" data-direction-body="${direction.id}">
+        <div class="min-h-0 overflow-hidden border-t border-slate-100 bg-white px-5 py-4">
+          ${direction.subdirections.length
+            ? `<ul class="flex flex-col gap-2 text-sm text-slate-600">
+                ${direction.subdirections
+                  .map(sub => `
+                    <li class="flex items-center justify-between gap-4 rounded-xl border border-slate-100 bg-slate-50 px-4 py-2">
+                      <span class="font-medium text-slate-700">${sub.name}</span>
+                      ${sub.code ? `<span class="rounded-full bg-white px-2 py-0.5 text-xs font-semibold text-slate-400">${sub.code}</span>` : ''}
+                    </li>
+                  `)
+                  .join('')}
+              </ul>`
+            : '<p class="rounded-xl border border-dashed border-slate-200 bg-slate-50/60 px-4 py-3 text-sm text-slate-400">No hay subdirecciones registradas en la matriz.</p>'}
+        </div>
+      </div>
+    </article>
+  `;
+}
+
+function buildHistoryTable(history = []) {
+  if (!history.length) {
     return `
-      <div class="bg-white rounded-xl border border-dashed border-slate-200 p-8 text-center text-sm text-slate-500">
-        No se encontraron indicadores críticos registrados.
+      <tr>
+        <td colspan="3" class="px-4 py-6 text-center text-slate-400">No hay mediciones registradas para este indicador.</td>
+      </tr>
+    `;
+  }
+
+  return history
+    .slice(-12)
+    .map(item => `
+      <tr class="hover:bg-slate-50/80">
+        <td class="px-4 py-2 text-left text-slate-600">${monthName(item.mes ?? 1)} ${item.anio}</td>
+        <td class="px-4 py-2 text-right font-medium text-slate-800">${formatNumber(item.valor)}</td>
+        <td class="px-4 py-2 text-right text-slate-500">${item.escenario ?? '—'}</td>
+      </tr>
+    `)
+    .join('');
+}
+
+function toggleAccordion(id, type) {
+  const attribute = type === 'card' ? 'data-card-body' : 'data-direction-body';
+  const toggleAttr = type === 'card' ? 'data-toggle-card' : 'data-toggle-direction';
+  const chevronAttr = type === 'card' ? 'data-chevron' : 'data-direction-chevron';
+
+  document.querySelectorAll(`[${attribute}]`).forEach(panel => {
+    const panelId = panel.getAttribute(attribute);
+    const isTarget = panelId === id;
+    const header = document.querySelector(`[${toggleAttr}="${panelId}"]`);
+    const chevron = document.querySelector(`[${chevronAttr}="${panelId}"]`);
+
+    if (isTarget) {
+      const expanded = panel.style.gridTemplateRows === '1fr';
+      if (expanded) {
+        panel.style.gridTemplateRows = '0fr';
+        panel.setAttribute('aria-hidden', 'true');
+        if (header) header.setAttribute('aria-expanded', 'false');
+        if (chevron) chevron.classList.remove('rotate-180');
+      } else {
+        panel.style.gridTemplateRows = '1fr';
+        panel.setAttribute('aria-hidden', 'false');
+        if (header) header.setAttribute('aria-expanded', 'true');
+        if (chevron) chevron.classList.add('rotate-180');
+      }
+    } else if (type === 'card') {
+      panel.style.gridTemplateRows = '0fr';
+      panel.setAttribute('aria-hidden', 'true');
+      const otherHeader = document.querySelector(`[${toggleAttr}="${panelId}"]`);
+      const otherChevron = document.querySelector(`[${chevronAttr}="${panelId}"]`);
+      if (otherHeader) otherHeader.setAttribute('aria-expanded', 'false');
+      if (otherChevron) otherChevron.classList.remove('rotate-180');
+    }
+  });
+
+}
+
+function ensureCardOpen(cardId) {
+  if (!cardId) return;
+  const panel = document.querySelector(`[data-card-body="${cardId}"]`);
+  if (!panel) return;
+  panel.style.gridTemplateRows = '1fr';
+  panel.setAttribute('aria-hidden', 'false');
+  const header = document.querySelector(`[data-toggle-card="${cardId}"]`);
+  const chevron = document.querySelector(`[data-chevron="${cardId}"]`);
+  if (header) header.setAttribute('aria-expanded', 'true');
+  if (chevron) chevron.classList.add('rotate-180');
+}
+
+function updateActiveOption(optionId) {
+  document.querySelectorAll('[data-option]').forEach(button => {
+    const idle = button.dataset.themeIdle ? button.dataset.themeIdle.split(' ') : [];
+    const active = button.dataset.themeActive ? button.dataset.themeActive.split(' ') : [];
+    const enabled = button.dataset.enabled === 'true';
+
+    button.classList.remove(...active);
+    if (enabled && idle.length) {
+      idle.forEach(cls => {
+        if (!button.classList.contains(cls)) {
+          button.classList.add(cls);
+        }
+      });
+    }
+    if (button.dataset.option === optionId) {
+      button.classList.remove(...idle);
+      if (active.length) {
+        active.forEach(cls => {
+          if (!button.classList.contains(cls)) {
+            button.classList.add(cls);
+          }
+        });
+      }
+      button.setAttribute('data-active', 'true');
+    } else {
+      button.removeAttribute('data-active');
+    }
+  });
+}
+
+function updateIndicatorInfo(indicator) {
+  const name = document.querySelector('[data-indicator-name]');
+  const description = document.querySelector('[data-indicator-description]');
+  const unit = document.querySelector('[data-indicator-unit]');
+  const value = document.querySelector('[data-indicator-value]');
+  const valueDate = document.querySelector('[data-indicator-value-date]');
+  const targetValue = document.querySelector('[data-indicator-target]');
+  const targetScenario = document.querySelector('[data-indicator-target-scenario]');
+  const alertBanner = document.querySelector('[data-indicator-alert]');
+
+  if (!indicator) {
+    if (name) name.textContent = 'Seleccione un indicador asignado';
+    if (description) {
+      description.textContent = '';
+      description.classList.add('hidden');
+    }
+    if (unit) unit.textContent = '—';
+    if (value) value.textContent = '—';
+    if (valueDate) valueDate.textContent = '';
+    if (targetValue) targetValue.textContent = '—';
+    if (targetScenario) targetScenario.textContent = '';
+    if (alertBanner) {
+      alertBanner.textContent = '';
+      alertBanner.classList.add('hidden');
+    }
+    return;
+  }
+
+  if (name) name.textContent = indicator.nombre ?? 'Indicador sin nombre';
+  if (description) {
+    description.textContent = indicator.descripcion ?? '';
+    description.classList.toggle('hidden', !indicator.descripcion);
+  }
+  if (unit) unit.textContent = indicator.unidad_medida ?? '—';
+  if (value) value.textContent = formatNumber(indicator.ultima_medicion_valor);
+  if (valueDate) {
+    valueDate.textContent = indicator.ultima_medicion_fecha
+      ? `Actualizado ${formatDate(indicator.ultima_medicion_fecha)}`
+      : '';
+  }
+  if (targetValue) targetValue.textContent = formatNumber(indicator.meta_vigente_valor);
+  if (targetScenario) {
+    targetScenario.textContent = indicator.meta_vigente_escenario
+      ? `Escenario ${indicator.meta_vigente_escenario}`
+      : '';
+  }
+  if (alertBanner) {
+    if (indicator.ultima_medicion_alerta) {
+      alertBanner.textContent = indicator.ultima_medicion_alerta;
+      alertBanner.classList.remove('hidden');
+    } else {
+      alertBanner.textContent = '';
+      alertBanner.classList.add('hidden');
+    }
+  }
+}
+
+async function loadIndicatorDetails(indicatorId) {
+  const chartWrapper = document.querySelector('[data-indicator-chart]');
+  const historyBody = document.querySelector('[data-history-body]');
+
+  if (!indicatorId) {
+    if (chartWrapper) {
+      chartWrapper.innerHTML = `
+        <div class="flex h-64 items-center justify-center rounded-xl border border-dashed border-slate-200 bg-white/60 text-sm text-slate-500">
+          Seleccione un indicador con información disponible.
+        </div>
+      `;
+    }
+    if (historyBody) {
+      historyBody.innerHTML = `
+        <tr>
+          <td colspan="3" class="px-4 py-6 text-center text-slate-400">No hay información para mostrar.</td>
+        </tr>
+      `;
+    }
+    return;
+  }
+
+  if (chartWrapper) {
+    chartWrapper.innerHTML = `
+      <div class="flex h-72 items-center justify-center text-slate-500">
+        <i class="fa-solid fa-spinner animate-spin mr-2"></i>
+        Cargando histórico...
       </div>
     `;
   }
 
-  return `
-    <div class="overflow-x-auto rounded-xl border border-slate-200 bg-white shadow-sm">
-      <table class="min-w-full divide-y divide-slate-200 text-sm">
-        <thead class="bg-slate-50">
-          <tr>
-            <th class="px-4 py-3 text-left font-semibold text-slate-500">Indicador</th>
-            <th class="px-4 py-3 text-left font-semibold text-slate-500">Área</th>
-            <th class="px-4 py-3 text-right font-semibold text-slate-500">Valor actual</th>
-            <th class="px-4 py-3 text-right font-semibold text-slate-500">Meta</th>
-            <th class="px-4 py-3 text-right font-semibold text-slate-500">Actualizado</th>
-          </tr>
-        </thead>
-        <tbody class="divide-y divide-slate-200">
-          ${highlights
-            .map((item) => {
-              return `
-                <tr class="hover:bg-slate-50">
-                  <td class="px-4 py-3 font-medium text-slate-700">${item.nombre ?? '—'}</td>
-                  <td class="px-4 py-3 text-slate-500">${item.area ?? item.area_nombre ?? '—'}</td>
-                  <td class="px-4 py-3 text-right font-semibold text-slate-800">${formatNumber(item.valor_actual)}</td>
-                  <td class="px-4 py-3 text-right text-slate-500">${formatNumber(item.meta ?? item.valor_meta)}</td>
-                  <td class="px-4 py-3 text-right text-slate-500">${formatDate(item.actualizado_en ?? item.fecha_actualizacion)}</td>
-                </tr>
-              `;
-            })
-            .join('')}
-        </tbody>
-      </table>
-    </div>
-  `;
-}
-
-function buildIndicatorCard(indicator, active) {
-  const categoryClass = OPERATIVE_NAMES.includes(indicator.nombre)
-    ? 'bg-emerald-100 text-emerald-700'
-    : FBO_NAMES.includes(indicator.nombre)
-    ? 'bg-sky-100 text-sky-700'
-    : 'bg-slate-100 text-slate-600';
-
-  return `
-    <button
-      class="w-full text-left rounded-2xl border px-4 py-4 transition ${
-        active ? 'border-transparent bg-slate-900 text-white shadow-lg shadow-slate-900/20' : 'border-slate-200 bg-white hover:border-slate-300'
-      }"
-      data-indicator="${indicator.id}"
-    >
-      <div class="flex items-start justify-between gap-3">
-        <div>
-          <p class="font-semibold">${indicator.nombre}</p>
-          <p class="text-sm text-slate-400">${indicator.area_nombre ?? '—'}</p>
-        </div>
-        <span class="text-xs px-2 py-1 rounded-full ${categoryClass}">
-          ${indicator.unidad_medida ?? 'Sin unidad'}
-        </span>
-      </div>
-      <div class="mt-3 flex flex-wrap items-center gap-4 text-xs ${active ? 'text-slate-200' : 'text-slate-500'}">
-        <span>
-          Última medición:
-          <strong class="ml-1">${formatNumber(indicator.ultima_medicion_valor)}</strong>
-        </span>
-        <span>
-          Actualizado ${formatDate(indicator.ultima_medicion_fecha)}
-        </span>
-      </div>
-    </button>
-  `;
-}
-
-async function renderIndicatorDetail(indicator, container) {
-  const panel = container.querySelector('#indicator-detail');
-  if (!panel) return;
-  panel.innerHTML = `
-    <div class="bg-white rounded-2xl border border-slate-200 p-6 shadow-sm">
-      <div class="flex items-center justify-between gap-4">
-        <div>
-          <h3 class="text-lg font-semibold text-slate-900">${indicator.nombre}</h3>
-          <p class="text-sm text-slate-500">${indicator.area_nombre ?? ''}</p>
-        </div>
-        <div class="text-right">
-          <p class="text-xs uppercase text-slate-400">Valor actual</p>
-          <p class="text-2xl font-semibold text-slate-800">${formatNumber(indicator.ultima_medicion_valor)}</p>
-        </div>
-      </div>
-      <div class="mt-6">
-        <div class="h-72" id="indicator-chart-wrapper">
-          <canvas id="indicator-chart"></canvas>
-        </div>
-      </div>
-    </div>
-  `;
-
-  const loader = panel.querySelector('#indicator-chart-wrapper');
-  loader.innerHTML = `
-    <div class="flex h-72 items-center justify-center text-slate-500">
-      <i class="fa-solid fa-spinner animate-spin mr-2"></i>
-      Cargando histórico...
-    </div>
-  `;
+  if (historyBody) {
+    historyBody.innerHTML = `
+      <tr>
+        <td colspan="3" class="px-4 py-6 text-center text-slate-400">Cargando mediciones...</td>
+      </tr>
+    `;
+  }
 
   try {
     const [history, targets] = await Promise.all([
-      getIndicatorHistory(indicator.id, { limit: 24 }),
-      getIndicatorTargets(indicator.id)
+      getIndicatorHistory(indicatorId, { limit: 36 }),
+      getIndicatorTargets(indicatorId)
     ]);
-    loader.innerHTML = '<canvas id="indicator-chart"></canvas>';
-    renderIndicatorChart('indicator-chart', history, targets);
+
+    if (chartWrapper) {
+      chartWrapper.innerHTML = '<canvas id="dashboard-indicator-chart" class="h-72 w-full"></canvas>';
+      renderIndicatorChart('dashboard-indicator-chart', history, targets);
+    }
+
+    if (historyBody) {
+      historyBody.innerHTML = buildHistoryTable(history ?? []);
+    }
   } catch (error) {
     console.error(error);
-    loader.innerHTML = `
-      <div class="bg-red-50 border border-red-200 text-red-600 rounded-xl p-6 text-sm">
-        No fue posible cargar la información histórica.
-      </div>
-    `;
+    if (chartWrapper) {
+      chartWrapper.innerHTML = `
+        <div class="rounded-xl border border-red-200 bg-red-50 px-4 py-6 text-sm text-red-600">
+          No fue posible cargar la información histórica.
+        </div>
+      `;
+    }
+    if (historyBody) {
+      historyBody.innerHTML = `
+        <tr>
+          <td colspan="3" class="px-4 py-6 text-center text-red-500">Ocurrió un error al cargar las mediciones.</td>
+        </tr>
+      `;
+    }
   }
 }
 
+function selectIndicator(optionId, indicator) {
+  if (optionId && indicator) {
+    updateActiveOption(optionId);
+    ensureCardOpen(document.querySelector(`[data-option="${optionId}"]`)?.dataset.cardOwner ?? null);
+  }
+
+  updateIndicatorInfo(indicator ?? null);
+  loadIndicatorDetails(indicator?.id ?? null);
+}
+
+function bindInteractions() {
+  document.querySelectorAll('[data-toggle-card]').forEach(button => {
+    button.addEventListener('click', () => {
+      const id = button.getAttribute('data-toggle-card');
+      if (!id) return;
+      toggleAccordion(id, 'card');
+    });
+  });
+
+  document.querySelectorAll('[data-toggle-direction]').forEach(button => {
+    button.addEventListener('click', () => {
+      const id = button.getAttribute('data-toggle-direction');
+      if (!id) return;
+      toggleAccordion(id, 'direction');
+    });
+  });
+
+  document.querySelectorAll('[data-option]').forEach(button => {
+    button.addEventListener('click', () => {
+      if (button.dataset.enabled !== 'true') return;
+      const optionId = button.dataset.option;
+      const indicatorId = button.dataset.indicatorId;
+      if (!indicatorId) return;
+      const indicator = button.__indicatorRef;
+      selectIndicator(optionId, indicator);
+    });
+  });
+}
+
+function hydrateOptionReferences(sections) {
+  sections.forEach(section => {
+    section.categories.forEach(category => {
+      category.options.forEach(option => {
+        const button = document.querySelector(`[data-option="${option.id}"]`);
+        if (button) {
+          button.__indicatorRef = option.indicator ?? null;
+        }
+      });
+    });
+  });
+}
+
 export async function renderDashboard(container) {
-  renderLoading(container, 'Preparando panel directivo...');
+  renderLoading(container, 'Preparando panel de análisis...');
+
   try {
-    const [summary, highlights, indicators] = await Promise.all([
+    const [summary, indicators] = await Promise.all([
       getDashboardSummary(),
-      getDirectorsHighlights().catch(() => []),
       getIndicators()
     ]);
 
-    if (!indicators.length) {
-      container.innerHTML = `
-        <div class="space-y-6">
-          <h2 class="text-2xl font-semibold text-slate-900">Panel directivo</h2>
-          ${buildSummaryCards(summary)}
-          <div class="bg-amber-50 border border-amber-200 text-amber-700 rounded-xl p-6">
-            Aún no hay indicadores configurados en el sistema.
-          </div>
-        </div>
-      `;
-      return;
-    }
+    const indicatorIndex = indicators.map(record => ({
+      record,
+      normalizedName: normalizeText(record.nombre),
+      normalizedDescription: normalizeText(record.descripcion),
+      normalizedArea: normalizeText(record.area_nombre ?? record.area)
+    }));
 
-    const activeIndicator = indicators[0];
+    const sections = INDICATOR_SECTIONS.map(section => ({
+      ...section,
+      categories: section.categories.map(category => {
+        const options = buildIndicatorOptions(category).map(option => {
+          const normalizedOption = normalizeText(option.label);
+          const match = indicatorIndex.find(entry => {
+            if (!entry.normalizedName && !entry.normalizedDescription) return false;
+            const haystacks = [entry.normalizedName, entry.normalizedDescription].filter(Boolean);
+            const sectionName = normalizeText(category.label);
+            const areaName = entry.normalizedArea;
+            const optionWords = normalizedOption.split(' ').filter(Boolean);
+            return haystacks.some(text => {
+              if (text.includes(normalizedOption)) return true;
+              const containsAllWords = optionWords.every(part => text.includes(part));
+              if (containsAllWords && sectionName && text.includes(sectionName)) {
+                return true;
+              }
+              if (containsAllWords && areaName && text.includes(areaName)) {
+                return true;
+              }
+              return false;
+            });
+          });
+          return { ...option, indicator: match?.record ?? null };
+        });
+        return { ...category, options };
+      })
+    }));
+
+    const directionsMap = new Map();
+    indicators.forEach(item => {
+      const directionName = item.direccion ?? item.direccion_nombre ?? item.area_direccion;
+      if (!directionName) return;
+      const key = normalizeText(directionName);
+      if (!directionsMap.has(key)) {
+        const fallback = DIRECTION_FALLBACKS.find(dir => normalizeText(dir.name) === key);
+        directionsMap.set(key, {
+          id: fallback?.id ?? key,
+          name: directionName,
+          code: item.direccion_codigo ?? item.direccion_clave ?? fallback?.code ?? buildCodeFromName(directionName),
+          palette: fallback?.palette ?? 'slate',
+          subdirections: new Map()
+        });
+      }
+      const subName = item.subdireccion ?? item.subdireccion_nombre ?? item.area_subdireccion;
+      if (subName) {
+        const entry = directionsMap.get(key);
+        const subKey = normalizeText(subName);
+        entry.subdirections.set(subKey, {
+          name: subName,
+          code: item.subdireccion_codigo ?? item.subdireccion_clave ?? buildCodeFromName(subName)
+        });
+      }
+    });
+
+    let directions = Array.from(directionsMap.values()).map(direction => ({
+      ...direction,
+      subdirections: Array.from(direction.subdirections.values()).sort((a, b) => a.name.localeCompare(b.name, 'es'))
+    }));
+
+    const existingDirectionKeys = new Set(directions.map(item => normalizeText(item.name)));
+    DIRECTION_FALLBACKS.forEach(fallback => {
+      const key = normalizeText(fallback.name);
+      if (!existingDirectionKeys.has(key)) {
+        directions.push({ ...fallback, subdirections: [] });
+      }
+    });
+
+    directions = directions.sort((a, b) => a.name.localeCompare(b.name, 'es'));
 
     container.innerHTML = `
       <div class="space-y-8">
-        <div class="flex flex-col gap-3">
-          <h2 class="text-2xl font-semibold text-slate-900">Panel directivo</h2>
-          <p class="text-sm text-slate-500">
-            Revisión ejecutiva de indicadores operativos y FBO con seguimiento a cumplimiento de metas.
-          </p>
-        </div>
-        ${buildSummaryCards(summary)}
-        <div class="grid lg:grid-cols-[22rem_1fr] gap-6">
-          <div class="space-y-4" id="indicator-list">
-            <h3 class="text-sm font-semibold text-slate-600">Indicadores estratégicos</h3>
-            <div class="space-y-3" id="indicator-buttons">
-              ${indicators.map((indicator, index) => buildIndicatorCard(indicator, index === 0)).join('')}
+        <header class="space-y-3 rounded-3xl border border-slate-200 bg-gradient-to-br from-white via-slate-50 to-slate-100 p-6 shadow-sm">
+          <div class="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+            <div>
+              <h1 class="text-2xl font-bold text-slate-900">Panel de Análisis de Indicadores</h1>
+              <p class="text-sm text-slate-500">Seleccione un indicador para consultar su tendencia y los escenarios de meta.</p>
             </div>
+            <div class="hidden items-center gap-2 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-2 text-sm text-amber-700" data-indicator-alert></div>
           </div>
-          <div id="indicator-detail"></div>
+        </header>
+
+        <section data-summary>${buildSummaryCards(summary)}</section>
+
+        <div class="grid gap-6 xl:grid-cols-[420px,1fr]">
+          <div class="space-y-6" data-indicator-sections>
+            ${sections
+              .map(section => `
+                <section class="space-y-4" data-section="${section.id}">
+                  <header>
+                    <h2 class="text-sm font-semibold uppercase tracking-widest text-slate-500">${section.title}</h2>
+                    <p class="text-xs text-slate-400">${section.description ?? ''}</p>
+                  </header>
+                  <div class="space-y-3">
+                    ${section.categories
+                      .map(category => buildIndicatorCard(category, category.options))
+                      .join('')}
+                  </div>
+                </section>
+              `)
+              .join('')}
+
+            <section class="space-y-4">
+              <header>
+                <h2 class="text-sm font-semibold uppercase tracking-widest text-slate-500">Direcciones</h2>
+                <p class="text-xs text-slate-400">Consulta la matriz de subdirecciones asignadas.</p>
+              </header>
+              <div class="space-y-3" data-directions>
+                ${directions.map(direction => buildDirectionCard(direction)).join('')}
+              </div>
+            </section>
+          </div>
+
+          <div class="space-y-6">
+            <section class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+              <div class="flex flex-wrap items-start justify-between gap-4">
+                <div>
+                  <p class="text-xs uppercase tracking-widest text-slate-400">Indicador seleccionado</p>
+                  <h2 class="mt-1 text-xl font-semibold text-slate-800" data-indicator-name>Seleccione un indicador asignado</h2>
+                  <p class="mt-2 max-w-2xl text-sm text-slate-500 hidden" data-indicator-description></p>
+                </div>
+                <div class="rounded-2xl bg-aifa-blue/10 px-4 py-2 text-right">
+                  <p class="text-xs uppercase tracking-widest text-aifa-blue">Unidad</p>
+                  <p class="text-sm font-semibold text-aifa-blue" data-indicator-unit>—</p>
+                </div>
+              </div>
+
+              <div class="mt-6 grid gap-4 md:grid-cols-2">
+                <div class="rounded-2xl border border-slate-100 bg-slate-50 p-4">
+                  <p class="text-xs uppercase tracking-widest text-slate-400">Valor actual</p>
+                  <p class="mt-2 text-2xl font-semibold text-slate-800" data-indicator-value>—</p>
+                  <p class="text-xs text-slate-500" data-indicator-value-date></p>
+                </div>
+                <div class="rounded-2xl border border-slate-100 bg-slate-50 p-4">
+                  <p class="text-xs uppercase tracking-widest text-slate-400">Meta vigente</p>
+                  <p class="mt-2 text-2xl font-semibold text-slate-800" data-indicator-target>—</p>
+                  <p class="text-xs text-slate-500" data-indicator-target-scenario></p>
+                </div>
+              </div>
+
+              <div class="mt-6" data-indicator-chart>
+                <div class="flex h-64 items-center justify-center rounded-xl border border-dashed border-slate-200 bg-white/60 text-sm text-slate-500">
+                  Seleccione un indicador con información disponible.
+                </div>
+              </div>
+            </section>
+
+            <section class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+              <h3 class="text-sm font-semibold uppercase tracking-widest text-slate-500">Historial reciente</h3>
+              <div class="mt-4 overflow-hidden rounded-2xl border border-slate-100">
+                <table class="min-w-full divide-y divide-slate-200 text-sm">
+                  <thead class="bg-slate-50 text-xs uppercase tracking-widest text-slate-500">
+                    <tr>
+                      <th class="px-4 py-2 text-left">Periodo</th>
+                      <th class="px-4 py-2 text-right">Valor</th>
+                      <th class="px-4 py-2 text-right">Escenario</th>
+                    </tr>
+                  </thead>
+                  <tbody class="divide-y divide-slate-100" data-history-body>
+                    <tr>
+                      <td colspan="3" class="px-4 py-6 text-center text-slate-400">Seleccione un indicador asignado.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </section>
+          </div>
         </div>
-        <section class="space-y-4">
-          <div class="flex items-center gap-3">
-            <i class="fa-solid fa-triangle-exclamation text-amber-500"></i>
-            <h3 class="text-lg font-semibold text-slate-800">Indicadores que requieren atención</h3>
-          </div>
-          ${buildHighlightsTable(highlights)}
-        </section>
       </div>
     `;
 
-    await renderIndicatorDetail(activeIndicator, container);
+    hydrateOptionReferences(sections);
+    bindInteractions();
 
-    const buttons = container.querySelectorAll('#indicator-buttons button[data-indicator]');
-    buttons.forEach((button) => {
-      button.addEventListener('click', async () => {
-        buttons.forEach((btn) => btn.classList.remove('border-transparent', 'bg-slate-900', 'text-white', 'shadow-lg', 'shadow-slate-900/20'));
-        buttons.forEach((btn) => btn.classList.add('border-slate-200', 'bg-white'));
-        button.classList.remove('border-slate-200', 'bg-white');
-        button.classList.add('border-transparent', 'bg-slate-900', 'text-white', 'shadow-lg', 'shadow-slate-900/20');
-        const selectedId = Number(button.dataset.indicator);
-        const selected = indicators.find((item) => Number(item.id) === selectedId);
-        if (!selected) return;
-        await renderIndicatorDetail(selected, container);
+    let firstAssigned = null;
+    sections.forEach(section => {
+      section.categories.forEach(category => {
+        const match = category.options.find(option => option.indicator);
+        if (!firstAssigned && match) {
+          firstAssigned = { option: match, cardId: category.id };
+        }
       });
     });
+
+    if (firstAssigned) {
+      ensureCardOpen(firstAssigned.cardId);
+      selectIndicator(firstAssigned.option.id, firstAssigned.option.indicator);
+    } else if (indicators.length) {
+      updateIndicatorInfo(indicators[0]);
+      loadIndicatorDetails(indicators[0].id);
+    }
   } catch (error) {
     console.error(error);
-    renderError(container, error);
-    showToast('No fue posible preparar el panel directivo.', { type: 'error' });
+    renderError(container, 'No fue posible cargar el panel de indicadores.');
+    showToast('Error al cargar la información del panel', { type: 'error' });
   }
 }

--- a/src/views/login.js
+++ b/src/views/login.js
@@ -8,7 +8,7 @@ export function renderLogin(container) {
       <div class="mx-auto flex min-h-screen max-w-6xl flex-col px-6 py-10">
         <header class="flex flex-col gap-6 text-slate-600 lg:flex-row lg:items-center lg:justify-between">
           <div class="flex items-center gap-4">
-            <img src="./assets/logo-aifa.svg" alt="Logotipo AIFA" class="h-16 w-auto" />
+            <img src="./assets/AIFA_logo.png" alt="Logotipo AIFA" class="h-16 w-auto" />
             <div>
               <p class="text-xs uppercase tracking-[0.35em] text-slate-400">Sistema de Indicadores AIFA</p>
               <h1 class="text-2xl font-semibold text-slate-800">Aeropuerto Internacional Felipe Ángeles</h1>

--- a/src/views/users.js
+++ b/src/views/users.js
@@ -1,0 +1,115 @@
+import { getUsers } from '../services/supabaseClient.js';
+import { formatDate } from '../utils/formatters.js';
+import { showToast } from '../ui/feedback.js';
+
+export async function renderUsers(container) {
+  container.innerHTML = `
+    <div class="flex h-72 items-center justify-center">
+      <div class="rounded-xl bg-white px-6 py-4 text-sm text-slate-500 shadow">Cargando usuarios...</div>
+    </div>
+  `;
+
+  try {
+    const users = await getUsers();
+
+    container.innerHTML = `
+      <div class="space-y-6">
+        <div class="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+          <div>
+            <h1 class="text-2xl font-bold text-slate-900">Administración de usuarios</h1>
+            <p class="text-sm text-slate-500">
+              Consulte los usuarios con acceso al sistema y su rol dentro de la plataforma.
+            </p>
+          </div>
+          <button
+            type="button"
+            class="inline-flex items-center gap-2 rounded-lg bg-primary-600 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-200"
+          >
+            <i class="fa-solid fa-user-plus"></i>
+            Nuevo usuario
+          </button>
+        </div>
+        <div class="rounded-2xl bg-white p-5 shadow">
+          <label class="flex items-center gap-3 rounded-xl border border-slate-200 px-4 py-2 text-sm text-slate-500">
+            <i class="fa-solid fa-magnifying-glass text-slate-400"></i>
+            <input
+              id="users-search"
+              type="search"
+              placeholder="Buscar por nombre, correo o rol"
+              class="w-full border-none bg-transparent text-sm focus:outline-none"
+            />
+          </label>
+        </div>
+        <div class="overflow-hidden rounded-2xl bg-white shadow">
+          <table class="min-w-full divide-y divide-slate-200 text-sm">
+            <thead class="bg-slate-50 text-xs uppercase tracking-widest text-slate-500">
+              <tr>
+                <th class="px-4 py-3 text-left">Nombre</th>
+                <th class="px-4 py-3 text-left">Correo</th>
+                <th class="px-4 py-3 text-left">Puesto</th>
+                <th class="px-4 py-3 text-left">Rol</th>
+                <th class="px-4 py-3 text-right">Último acceso</th>
+              </tr>
+            </thead>
+            <tbody id="users-table" class="divide-y divide-slate-100"></tbody>
+          </table>
+        </div>
+      </div>
+    `;
+
+    const searchInput = container.querySelector('#users-search');
+    const tableBody = container.querySelector('#users-table');
+
+    function renderRows(term = '') {
+      const normalized = term.trim().toLowerCase();
+      const filtered = normalized
+        ? users.filter(user =>
+            [user.nombre, user.email, user.rol, user.puesto]
+              .filter(Boolean)
+              .some(value => value.toString().toLowerCase().includes(normalized))
+          )
+        : users;
+
+      tableBody.innerHTML = filtered
+        .map(
+          user => `
+            <tr class="hover:bg-slate-50/80">
+              <td class="px-4 py-3">
+                <p class="font-semibold text-slate-800">${user.nombre}</p>
+                ${user.direccion ? `<p class="text-xs text-slate-400">${user.direccion}</p>` : ''}
+              </td>
+              <td class="px-4 py-3 text-slate-600">${user.email ?? '—'}</td>
+              <td class="px-4 py-3 text-slate-600">${user.puesto ?? '—'}</td>
+              <td class="px-4 py-3 text-slate-600">${user.rol ?? '—'}</td>
+              <td class="px-4 py-3 text-right text-slate-500">${formatDate(user.ultimo_acceso)}</td>
+            </tr>
+          `
+        )
+        .join('');
+
+      if (!filtered.length) {
+        tableBody.innerHTML = `
+          <tr>
+            <td colspan="5" class="px-4 py-10 text-center text-slate-400">
+              No se encontraron usuarios que coincidan con la búsqueda.
+            </td>
+          </tr>
+        `;
+      }
+    }
+
+    renderRows();
+
+    searchInput.addEventListener('input', event => {
+      renderRows(event.target.value);
+    });
+  } catch (error) {
+    console.error(error);
+    container.innerHTML = `
+      <div class="rounded-2xl border border-red-200 bg-red-50 p-6 text-sm text-red-600">
+        No fue posible cargar la administración de usuarios.
+      </div>
+    `;
+    showToast('No fue posible cargar la administración de usuarios.', { type: 'error' });
+  }
+}

--- a/src/views/visualization.js
+++ b/src/views/visualization.js
@@ -1,0 +1,397 @@
+import {
+  getIndicators,
+  getIndicatorHistory,
+  getIndicatorTargets
+} from '../services/supabaseClient.js';
+import { formatNumber } from '../utils/formatters.js';
+import { showToast } from '../ui/feedback.js';
+
+function combineHistory(history = [], targets = []) {
+  const rows = new Map();
+
+  history.forEach(item => {
+    const key = `${item.anio}-${item.mes}`;
+    const value =
+      item.valor ?? item.valor_medido ?? item.valor_real ?? item.valor_actual ?? item.cantidad ?? null;
+    rows.set(key, {
+      key,
+      label: formatPeriod(item.anio, item.mes),
+      real: value !== null && value !== undefined ? Number(value) : null,
+      escenario: item.escenario ?? null
+    });
+  });
+
+  targets.forEach(item => {
+    const key = `${item.anio}-${item.mes}`;
+    const scenario = (item.escenario ?? 'meta').toString().toLowerCase();
+    const existing = rows.get(key) ?? {
+      key,
+      label: formatPeriod(item.anio, item.mes)
+    };
+    const value = item.valor ?? item.valor_meta ?? item.meta ?? null;
+    rows.set(key, {
+      ...existing,
+      [`meta_${scenario}`]: value !== null && value !== undefined ? Number(value) : null
+    });
+  });
+
+  return Array.from(rows.values()).sort((a, b) => (a.key > b.key ? 1 : -1));
+}
+
+function formatPeriod(year, month = 1) {
+  const monthNames = [
+    'Ene',
+    'Feb',
+    'Mar',
+    'Abr',
+    'May',
+    'Jun',
+    'Jul',
+    'Ago',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dic'
+  ];
+  const label = monthNames[(month ?? 1) - 1] ?? '';
+  return `${label} ${year}`.trim();
+}
+
+function renderChart(history = []) {
+  if (!history.length) {
+    return `
+      <div class="flex h-72 items-center justify-center rounded-xl border border-dashed border-slate-200 bg-white/70">
+        <div class="text-center text-sm text-slate-500">
+          <i class="fa-solid fa-chart-line mb-2 text-lg"></i>
+          No hay suficientes datos históricos para graficar este indicador.
+        </div>
+      </div>
+    `;
+  }
+
+  const values = history.flatMap(row => [row.real, row.meta_bajo, row.meta_medio, row.meta_alto]).filter(v => v !== null && v !== undefined);
+  const min = values.length ? Math.min(...values) : 0;
+  const max = values.length ? Math.max(...values) : 1;
+  const safeMin = Number.isFinite(min) ? min : 0;
+  const safeMax = Number.isFinite(max) && max !== min ? max : safeMin + 1;
+  const width = 680;
+  const height = 260;
+  const padding = 40;
+  const step = history.length > 1 ? (width - padding * 2) / (history.length - 1) : 0;
+
+  function mapPoints(key) {
+    return history
+      .map((row, index) => {
+        const value = row[key];
+        if (value === null || value === undefined) return null;
+        const x = padding + index * step;
+        const y = padding + (1 - (value - safeMin) / (safeMax - safeMin)) * (height - padding * 2);
+        return `${x},${y}`;
+      })
+      .filter(Boolean)
+      .join(' ');
+  }
+
+  const lineReal = mapPoints('real');
+  const lineMetaBajo = mapPoints('meta_bajo');
+  const lineMetaMedio = mapPoints('meta_medio');
+  const lineMetaAlto = mapPoints('meta_alto');
+
+  const axisLabels = history
+    .map((row, index) => {
+      const x = padding + index * step;
+      return `<text x="${x}" y="${height - 8}" text-anchor="middle" class="fill-slate-400 text-[10px]">${row.label}</text>`;
+    })
+    .join('');
+
+  return `
+    <div class="rounded-2xl border border-slate-200 bg-white/80 p-4">
+      <svg viewBox="0 0 ${width} ${height}" class="w-full" role="img" aria-label="Tendencia histórica del indicador">
+        <defs>
+          <linearGradient id="lineReal" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="5%" stop-color="rgba(30,58,138,0.35)" />
+            <stop offset="95%" stop-color="rgba(30,58,138,0)" />
+          </linearGradient>
+        </defs>
+        <rect x="${padding}" y="${padding}" width="${width - padding * 2}" height="${height - padding * 2}" fill="none" stroke="#E2E8F0" stroke-width="1" />
+        ${lineReal ? `<polyline points="${lineReal}" fill="none" stroke="#1E3A8A" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" />` : ''}
+        ${lineMetaBajo ? `<polyline points="${lineMetaBajo}" fill="none" stroke="#F97316" stroke-width="2" stroke-dasharray="6 3" />` : ''}
+        ${lineMetaMedio ? `<polyline points="${lineMetaMedio}" fill="none" stroke="#0EA5E9" stroke-width="2" stroke-dasharray="6 3" />` : ''}
+        ${lineMetaAlto ? `<polyline points="${lineMetaAlto}" fill="none" stroke="#059669" stroke-width="2" stroke-dasharray="6 3" />` : ''}
+        ${axisLabels}
+      </svg>
+      <div class="mt-4 flex flex-wrap items-center gap-3 text-xs text-slate-500">
+        <span class="inline-flex items-center gap-2"><span class="h-2 w-8 rounded-full bg-[#1E3A8A]"></span> Valor real</span>
+        <span class="inline-flex items-center gap-2"><span class="h-2 w-8 rounded-full bg-[#F97316]"></span> Meta escenario bajo</span>
+        <span class="inline-flex items-center gap-2"><span class="h-2 w-8 rounded-full bg-[#0EA5E9]"></span> Meta escenario medio</span>
+        <span class="inline-flex items-center gap-2"><span class="h-2 w-8 rounded-full bg-[#059669]"></span> Meta escenario alto</span>
+      </div>
+    </div>
+  `;
+}
+
+function areaKey(indicator) {
+  return String(
+    indicator.area_id ??
+      indicator.areaId ??
+      indicator.area_codigo ??
+      indicator.area ??
+      indicator.area_nombre ??
+      'sin-area'
+  );
+}
+
+function areaName(indicator) {
+  return indicator.area_nombre ?? indicator.area ?? 'Sin área asignada';
+}
+
+export async function renderVisualization(container) {
+  container.innerHTML = `
+    <div class="flex h-72 items-center justify-center">
+      <div class="rounded-xl bg-white px-6 py-4 text-sm text-slate-500 shadow">Cargando indicadores...</div>
+    </div>
+  `;
+
+  try {
+    const indicators = await getIndicators();
+    if (!indicators.length) {
+      container.innerHTML = `
+        <div class="rounded-2xl border border-dashed border-slate-200 bg-white/70 p-8 text-center text-sm text-slate-500">
+          No se encontraron indicadores disponibles para visualizar.
+        </div>
+      `;
+      return;
+    }
+
+    const areasMap = new Map();
+    indicators.forEach(indicator => {
+      const key = areaKey(indicator);
+      if (!areasMap.has(key)) {
+        areasMap.set(key, {
+          id: key,
+          name: areaName(indicator)
+        });
+      }
+    });
+
+    let selectedArea = areasMap.keys().next().value;
+    let selectedIndicator = indicators.find(item => areaKey(item) === selectedArea)?.id ?? indicators[0].id;
+
+    container.innerHTML = `
+      <div class="space-y-6">
+        <div class="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+          <div>
+            <h1 class="text-2xl font-bold text-slate-900">Visualización de indicadores</h1>
+            <p class="text-sm text-slate-500">
+              Seleccione el área y posteriormente el indicador para consultar su tendencia histórica.
+            </p>
+          </div>
+        </div>
+        <div class="grid gap-4 rounded-2xl bg-white p-6 shadow md:grid-cols-2 lg:grid-cols-3">
+          <label class="flex flex-col gap-2">
+            <span class="text-xs font-semibold uppercase tracking-widest text-slate-400">Área</span>
+            <div class="flex items-center gap-2 rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm">
+              <i class="fa-solid fa-filter text-slate-400"></i>
+              <select id="visualization-area" class="w-full border-none bg-transparent text-sm focus:outline-none"></select>
+            </div>
+          </label>
+          <label class="flex flex-col gap-2 md:col-span-1 lg:col-span-2">
+            <span class="text-xs font-semibold uppercase tracking-widest text-slate-400">Indicador</span>
+            <div class="flex items-center gap-2 rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm">
+              <i class="fa-solid fa-filter text-slate-400"></i>
+              <select id="visualization-indicator" class="w-full border-none bg-transparent text-sm focus:outline-none"></select>
+            </div>
+            <p id="visualization-empty" class="hidden text-xs text-slate-400">No hay indicadores registrados para el área seleccionada.</p>
+          </label>
+        </div>
+        <div class="grid gap-6 lg:grid-cols-[360px,1fr]">
+          <div class="space-y-4">
+            <section class="rounded-2xl bg-white p-6 shadow" id="visualization-area-card"></section>
+            <section class="rounded-2xl bg-white p-6 shadow" id="visualization-indicator-card"></section>
+          </div>
+          <section class="space-y-6 rounded-2xl bg-white p-6 shadow">
+            <div class="flex items-center justify-between">
+              <h3 class="text-sm font-semibold uppercase tracking-widest text-slate-400">Tendencia histórica</h3>
+              <span id="visualization-status" class="text-xs text-slate-400">Actualizando datos...</span>
+            </div>
+            <div id="visualization-chart"></div>
+            <div class="overflow-hidden rounded-xl border border-slate-100">
+              <table class="min-w-full divide-y divide-slate-200 text-sm">
+                <thead class="bg-slate-50 text-xs uppercase tracking-widest text-slate-500">
+                  <tr>
+                    <th class="px-4 py-2 text-left">Periodo</th>
+                    <th class="px-4 py-2 text-right">Valor</th>
+                    <th class="px-4 py-2 text-right">Escenario</th>
+                  </tr>
+                </thead>
+                <tbody id="visualization-history" class="divide-y divide-slate-100"></tbody>
+              </table>
+            </div>
+          </section>
+        </div>
+      </div>
+    `;
+
+    const areaSelect = container.querySelector('#visualization-area');
+    const indicatorSelect = container.querySelector('#visualization-indicator');
+    const emptyMessage = container.querySelector('#visualization-empty');
+    const areaCard = container.querySelector('#visualization-area-card');
+    const indicatorCard = container.querySelector('#visualization-indicator-card');
+    const statusLabel = container.querySelector('#visualization-status');
+    const chartContainer = container.querySelector('#visualization-chart');
+    const historyBody = container.querySelector('#visualization-history');
+
+    function renderAreaOptions() {
+      areaSelect.innerHTML = Array.from(areasMap.values())
+        .map(area => `<option value="${area.id}" ${area.id === selectedArea ? 'selected' : ''}>${area.name}</option>`)
+        .join('');
+    }
+
+    function getIndicatorsForArea(areaId) {
+      return indicators
+        .filter(item => areaKey(item) === areaId)
+        .sort((a, b) => (a.nombre ?? '').localeCompare(b.nombre ?? ''));
+    }
+
+    function renderIndicatorOptions() {
+      const indicatorsForArea = getIndicatorsForArea(selectedArea);
+      indicatorSelect.innerHTML = indicatorsForArea
+        .map(
+          indicator => `
+            <option value="${indicator.id}" ${String(indicator.id) === String(selectedIndicator) ? 'selected' : ''}>
+              ${indicator.nombre}
+            </option>
+          `
+        )
+        .join('');
+      indicatorSelect.disabled = indicatorsForArea.length === 0;
+      emptyMessage.classList.toggle('hidden', indicatorsForArea.length > 0);
+      if (!indicatorsForArea.length) {
+        selectedIndicator = null;
+      } else if (!indicatorsForArea.some(item => String(item.id) === String(selectedIndicator))) {
+        selectedIndicator = indicatorsForArea[0].id;
+      }
+    }
+
+    function renderAreaCard() {
+      const areaInfo = areasMap.get(selectedArea);
+      areaCard.innerHTML = `
+        <p class="text-xs uppercase tracking-widest text-slate-400">Área seleccionada</p>
+        <h2 class="mt-2 text-lg font-semibold text-slate-800">${areaInfo?.name ?? 'Seleccione un área'}</h2>
+        <p class="mt-3 text-sm text-slate-500">Seleccione un indicador para visualizar su comportamiento histórico.</p>
+      `;
+    }
+
+    function renderIndicatorCard(indicator) {
+      if (!indicator) {
+        indicatorCard.innerHTML = `
+          <p class="text-xs uppercase tracking-widest text-slate-400">Indicador</p>
+          <p class="mt-2 text-sm text-slate-500">No hay indicadores disponibles para esta área.</p>
+        `;
+        return;
+      }
+
+      indicatorCard.innerHTML = `
+        <p class="text-xs uppercase tracking-widest text-slate-400">Indicador</p>
+        <h2 class="mt-2 text-lg font-semibold text-slate-800">${indicator.nombre ?? 'Sin nombre'}</h2>
+        ${indicator.descripcion ? `<p class="mt-3 text-sm text-slate-500">${indicator.descripcion}</p>` : ''}
+        <div class="mt-4 grid gap-3 text-sm text-slate-500">
+          <div class="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3">
+            <p class="text-[11px] uppercase tracking-[0.35em] text-slate-400">Unidad</p>
+            <p class="mt-1 text-base font-semibold text-slate-800">${indicator.unidad_medida ?? 'No definida'}</p>
+          </div>
+          <div class="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3">
+            <p class="text-[11px] uppercase tracking-[0.35em] text-slate-400">Meta vigente</p>
+            <p class="mt-1 text-base font-semibold text-slate-800">${formatNumber(indicator.meta_vigente_valor)}</p>
+            <p class="text-xs text-slate-500">Escenario ${indicator.meta_vigente_escenario ?? '—'}</p>
+          </div>
+        </div>
+      `;
+    }
+
+    async function loadHistory() {
+      if (!selectedIndicator) {
+        chartContainer.innerHTML = renderChart([]);
+        historyBody.innerHTML = `
+          <tr>
+            <td colspan="3" class="px-4 py-6 text-center text-slate-400">Seleccione un indicador para ver su historial.</td>
+          </tr>
+        `;
+        statusLabel.textContent = 'Seleccione un indicador';
+        return;
+      }
+
+      statusLabel.textContent = 'Actualizando datos...';
+      try {
+        const [history, targets] = await Promise.all([
+          getIndicatorHistory(selectedIndicator, { limit: 36 }),
+          getIndicatorTargets(selectedIndicator)
+        ]);
+        const combined = combineHistory(history, targets);
+        chartContainer.innerHTML = renderChart(combined);
+        historyBody.innerHTML = combined
+          .map(
+            row => `
+              <tr>
+                <td class="px-4 py-2 text-slate-600">${row.label}</td>
+                <td class="px-4 py-2 text-right font-medium text-slate-800">${formatNumber(row.real)}</td>
+                <td class="px-4 py-2 text-right text-slate-500">${row.escenario ?? '—'}</td>
+              </tr>
+            `
+          )
+          .join('');
+
+        if (!combined.length) {
+          historyBody.innerHTML = `
+            <tr>
+              <td colspan="3" class="px-4 py-6 text-center text-slate-400">No hay registros históricos para este indicador.</td>
+            </tr>
+          `;
+        }
+        statusLabel.textContent = 'Datos actualizados';
+      } catch (error) {
+        console.error(error);
+        chartContainer.innerHTML = renderChart([]);
+        historyBody.innerHTML = `
+          <tr>
+            <td colspan="3" class="px-4 py-6 text-center text-red-500">No fue posible obtener el historial del indicador.</td>
+          </tr>
+        `;
+        statusLabel.textContent = 'Error al cargar los datos';
+        showToast('No fue posible obtener el historial del indicador seleccionado.', { type: 'error' });
+      }
+    }
+
+    renderAreaOptions();
+    renderIndicatorOptions();
+    renderAreaCard();
+    const initialIndicator = indicators.find(item => String(item.id) === String(selectedIndicator)) ?? null;
+    renderIndicatorCard(initialIndicator);
+    await loadHistory();
+
+    areaSelect.addEventListener('change', async event => {
+      selectedArea = event.target.value;
+      renderIndicatorOptions();
+      renderAreaCard();
+      const indicator = indicators.find(item => String(item.id) === String(selectedIndicator)) ?? null;
+      renderIndicatorCard(indicator);
+      await loadHistory();
+    });
+
+    indicatorSelect.addEventListener('change', async event => {
+      const indicatorsForArea = getIndicatorsForArea(selectedArea);
+      const selected = indicatorsForArea.find(item => String(item.id) === event.target.value);
+      selectedIndicator = selected?.id ?? null;
+      renderIndicatorCard(selected ?? null);
+      await loadHistory();
+    });
+  } catch (error) {
+    console.error(error);
+    container.innerHTML = `
+      <div class="rounded-2xl border border-red-200 bg-red-50 p-6 text-sm text-red-600">
+        No fue posible cargar la visualización de indicadores.
+      </div>
+    `;
+    showToast('No fue posible cargar la visualización de indicadores.', { type: 'error' });
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared dashboard configuration module with indicator option templates and direction fallbacks
- redesign the directors dashboard in React to use accordion cards, area templates, and enhanced history panels while matching the requested UI
- mirror the new panel experience in the static dashboard and ensure hash navigation sign-out clears the stored session

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db10353630832e98988cd6d0c57f14