### PR TITLE
Implement capture validation workflow and area restrictions

### DIFF
--- a/sql/mediciones_control.sql
+++ b/sql/mediciones_control.sql
@@ -1,0 +1,89 @@
+-- Controles de validación y bitácora para mediciones operativas
+
+-- 1. Columnas de control en la tabla principal
+alter table if exists public.mediciones
+  add column if not exists capturado_por uuid references public.perfiles(id),
+  add column if not exists editado_por uuid references public.perfiles(id),
+  add column if not exists validado_por uuid references public.perfiles(id),
+  add column if not exists fecha_captura timestamptz not null default now(),
+  add column if not exists fecha_ultima_edicion timestamptz not null default now(),
+  add column if not exists fecha_validacion timestamptz,
+  add column if not exists estatus_validacion text not null default 'PENDIENTE' check (upper(estatus_validacion) in ('PENDIENTE','VALIDADO','RECHAZADO')),
+  add column if not exists observaciones_validacion text;
+
+-- 2. Trigger para mantener consistencia en fechas y estatus
+create or replace function public.fn_set_mediciones_metadata()
+returns trigger as
+$$
+begin
+    if tg_op = 'INSERT' and new.fecha_captura is null then
+        new.fecha_captura := now();
+    end if;
+
+    new.estatus_validacion := upper(coalesce(new.estatus_validacion, 'PENDIENTE'));
+    new.fecha_ultima_edicion := now();
+
+    if new.estatus_validacion <> 'VALIDADO' then
+        new.fecha_validacion := null;
+        new.validado_por := null;
+    elsif new.fecha_validacion is null then
+        new.fecha_validacion := now();
+    end if;
+
+    if new.observaciones_validacion is not null and btrim(new.observaciones_validacion) = '' then
+        new.observaciones_validacion := null;
+    end if;
+
+    return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists set_timestamp_mediciones on public.mediciones;
+create trigger set_timestamp_mediciones
+    before insert or update on public.mediciones
+    for each row
+    execute function public.fn_set_mediciones_metadata();
+
+-- 3. Bitácora de cambios de mediciones
+create table if not exists public.mediciones_bitacora (
+    id uuid primary key default gen_random_uuid(),
+    medicion_id uuid not null references public.mediciones(id) on delete cascade,
+    accion text not null,
+    detalle jsonb,
+    realizado_por uuid references public.perfiles(id),
+    realizado_en timestamptz not null default now()
+);
+
+create index if not exists mediciones_bitacora_medicion_idx on public.mediciones_bitacora (medicion_id);
+create index if not exists mediciones_bitacora_realizado_en_idx on public.mediciones_bitacora (realizado_en desc);
+
+-- 4. Trigger de auditoría para capturar inserciones y actualizaciones
+create or replace function public.fn_log_mediciones_historial()
+returns trigger as
+$$
+declare
+    detalle jsonb;
+    actor uuid;
+begin
+    if tg_op = 'INSERT' then
+        actor := new.capturado_por;
+        detalle := jsonb_build_object('nuevo', to_jsonb(new));
+    elsif tg_op = 'UPDATE' then
+        actor := coalesce(new.editado_por, new.validado_por);
+        detalle := jsonb_build_object('antes', to_jsonb(old), 'despues', to_jsonb(new));
+    else
+        return new;
+    end if;
+
+    insert into public.mediciones_bitacora (medicion_id, accion, detalle, realizado_por)
+    values (new.id, tg_op, detalle, actor);
+
+    return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists log_mediciones_history on public.mediciones;
+create trigger log_mediciones_history
+    after insert or update on public.mediciones
+    for each row
+    execute function public.fn_log_mediciones_historial();

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -34,12 +34,35 @@ export function AuthProvider({ children }) {
       try {
         const { data, error } = await supabase
           .from('perfiles')
-          .select('id, nombre_completo, puesto, rol, avatar_url, usuario:usuarios(email)')
+          .select(
+            [
+              'id',
+              'nombre_completo',
+              'nombre',
+              'puesto',
+              'rol',
+              'avatar_url',
+              'area_id',
+              'subdireccion_id',
+              'area:areas(id,nombre,clave,parent_area_id)',
+              'usuario:usuarios(email)'
+            ].join(',')
+          )
           .eq('usuario_id', currentSession.user.id)
           .maybeSingle();
 
         if (error) throw error;
-        setProfile(data ? { ...data, nombre: data.nombre_completo ?? data.nombre } : null);
+        setProfile(
+          data
+            ? {
+                ...data,
+                nombre: data.nombre_completo ?? data.nombre,
+                area_id: data.area_id ?? data.area?.id ?? null,
+                area: data.area ?? null,
+                subdireccion_id: data.subdireccion_id ?? null
+              }
+            : null
+        );
       } catch (err) {
         console.error('Error cargando perfil', err);
         setProfile(null);

--- a/src/lib/supabaseClient.js
+++ b/src/lib/supabaseClient.js
@@ -29,12 +29,29 @@ function normalizeStatus(value) {
 
 function normalizeMeasurement(record) {
   if (!record) return record;
+  const status =
+    record.estatus_validacion ??
+    record.estado_validacion ??
+    record.estatus ??
+    (typeof record.validado === 'boolean'
+      ? record.validado
+        ? 'VALIDADO'
+        : 'PENDIENTE'
+      : null);
+
   return {
     ...record,
     escenario: record.escenario ? record.escenario.toUpperCase() : null,
+    estatus_validacion: typeof status === 'string' ? status.toUpperCase() : status ?? 'PENDIENTE',
     fecha_captura: record.fecha_captura ?? record.creado_en ?? null,
     fecha_actualizacion:
-      record.fecha_actualizacion ?? record.fecha_ultima_edicion ?? record.actualizado_en ?? null
+      record.fecha_actualizacion ?? record.fecha_ultima_edicion ?? record.actualizado_en ?? null,
+    fecha_validacion: record.fecha_validacion ?? record.validado_en ?? null,
+    validado_por: record.validado_por ?? record.subdirector_id ?? null,
+    observaciones_validacion:
+      record.observaciones_validacion ?? record.validacion_observaciones ?? null,
+    capturado_por: record.capturado_por ?? record.creado_por ?? null,
+    editado_por: record.editado_por ?? record.actualizado_por ?? null
   };
 }
 
@@ -45,7 +62,9 @@ function normalizeTarget(record) {
     escenario: record.escenario ? record.escenario.toUpperCase() : null,
     fecha_captura: record.fecha_captura ?? record.creado_en ?? null,
     fecha_actualizacion:
-      record.fecha_actualizacion ?? record.fecha_ultima_edicion ?? record.actualizado_en ?? null
+      record.fecha_actualizacion ?? record.fecha_ultima_edicion ?? record.actualizado_en ?? null,
+    capturado_por: record.capturado_por ?? record.creado_por ?? null,
+    editado_por: record.editado_por ?? record.actualizado_por ?? null
   };
 }
 
@@ -279,14 +298,23 @@ export async function getIndicatorTargets(indicadorId, { year } = {}) {
 }
 
 export async function saveMeasurement(payload) {
-  const sanitized = sanitizeScenario(payload);
+  const sanitized = sanitizeScenario(payload ? { ...payload } : payload);
+  if (sanitized && !('estatus_validacion' in sanitized)) {
+    sanitized.estatus_validacion = 'PENDIENTE';
+  }
+  if (sanitized && typeof sanitized.estatus_validacion === 'string') {
+    sanitized.estatus_validacion = sanitized.estatus_validacion.toUpperCase();
+  }
   const { data, error } = await supabase.from('mediciones').insert(sanitized).select().single();
   if (error) throw error;
   return normalizeMeasurement(data);
 }
 
 export async function updateMeasurement(id, payload) {
-  const sanitized = sanitizeScenario(payload);
+  const sanitized = sanitizeScenario(payload ? { ...payload } : payload);
+  if (sanitized && typeof sanitized.estatus_validacion === 'string') {
+    sanitized.estatus_validacion = sanitized.estatus_validacion.toUpperCase();
+  }
   const { data, error } = await supabase
     .from('mediciones')
     .update(sanitized)
@@ -295,6 +323,19 @@ export async function updateMeasurement(id, payload) {
     .single();
   if (error) throw error;
   return normalizeMeasurement(data);
+}
+
+export async function validateMeasurement(id, { validado_por, observaciones = null } = {}) {
+  if (!id) throw new Error('Se requiere un identificador de medición para validar.');
+  const payload = {
+    estatus_validacion: 'VALIDADO',
+    validado_por: validado_por ?? null,
+    fecha_validacion: new Date().toISOString()
+  };
+  if (observaciones !== undefined) {
+    payload.observaciones_validacion = observaciones;
+  }
+  return updateMeasurement(id, payload);
 }
 
 export async function upsertTarget(payload) {

--- a/src/pages/CapturePage.jsx
+++ b/src/pages/CapturePage.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
@@ -6,16 +6,35 @@ import {
   getIndicatorHistory,
   getIndicatorTargets,
   saveMeasurement,
+  updateMeasurement,
+  validateMeasurement,
   upsertTarget
 } from '../lib/supabaseClient.js';
-import { formatMonth, formatNumber } from '../utils/formatters.js';
-import { CheckCircle2, Loader2, PlusCircle, Target } from 'lucide-react';
+import { formatDate, formatMonth, formatNumber } from '../utils/formatters.js';
+import {
+  BadgeCheck,
+  CheckCircle2,
+  Clock,
+  Loader2,
+  PencilLine,
+  PlusCircle,
+  ShieldCheck,
+  Target,
+  Undo2
+} from 'lucide-react';
+import { useAuth } from '../context/AuthContext.jsx';
 
 const SCENARIOS = [
   { value: 'BAJO', label: 'Escenario bajo' },
   { value: 'MEDIO', label: 'Escenario medio' },
   { value: 'ALTO', label: 'Escenario alto' }
 ];
+
+const VALIDATION_LABELS = {
+  PENDIENTE: 'Pendiente de validación',
+  VALIDADO: 'Validado por subdirección',
+  RECHAZADO: 'Rechazado por subdirección'
+};
 
 function SectionCard({ title, description, icon: Icon, children }) {
   return (
@@ -34,29 +53,158 @@ function SectionCard({ title, description, icon: Icon, children }) {
   );
 }
 
+function normalizeId(value) {
+  if (!value) return null;
+  if (typeof value === 'object') {
+    if ('id' in value && value.id) return value.id;
+    if ('value' in value && value.value) return value.value;
+  }
+  return value;
+}
+
+function resolveIndicatorAreaIds(indicator) {
+  const ids = new Set();
+  if (!indicator || typeof indicator !== 'object') return ids;
+  const directCandidates = [
+    indicator.area_id,
+    indicator.areaId,
+    indicator.areaID,
+    indicator.areaid,
+    indicator.area?.id,
+    indicator.area?.area_id
+  ];
+  const parentCandidates = [
+    indicator.parent_area_id,
+    indicator.parentAreaId,
+    indicator.area_parent_id,
+    indicator.area?.parent_area_id,
+    indicator.subdireccion_id
+  ];
+
+  for (const candidate of [...directCandidates, ...parentCandidates]) {
+    const normalized = normalizeId(candidate);
+    if (normalized) {
+      ids.add(String(normalized));
+    }
+  }
+
+  return ids;
+}
+
+function resolveIndicatorAreaName(indicator) {
+  if (!indicator || typeof indicator !== 'object') return 'Área no definida';
+  return (
+    indicator.area_nombre ??
+    indicator.areaName ??
+    indicator.area?.nombre ??
+    indicator.area_descripcion ??
+    indicator.area ??
+    'Área no definida'
+  );
+}
+
+function resolveIndicatorUnit(indicator) {
+  if (!indicator || typeof indicator !== 'object') return 'No definida';
+  return (
+    indicator.unidad_medida ??
+    indicator.unidad ??
+    indicator.unidadMedida ??
+    indicator.unidad_de_medida ??
+    'No definida'
+  );
+}
+
+function computeValidationStatus(record) {
+  if (!record || typeof record !== 'object') return 'PENDIENTE';
+  const rawStatus =
+    record.estatus_validacion ??
+    record.estado_validacion ??
+    record.estatus ??
+    (typeof record.validado === 'boolean'
+      ? record.validado
+        ? 'VALIDADO'
+        : 'PENDIENTE'
+      : null);
+
+  if (typeof rawStatus === 'string' && rawStatus.trim().length) {
+    return rawStatus.trim().toUpperCase();
+  }
+
+  if (record.validado_por) {
+    return 'VALIDADO';
+  }
+
+  return 'PENDIENTE';
+}
+
+function getStatusBadgeClass(status) {
+  switch (status) {
+    case 'VALIDADO':
+      return 'bg-emerald-100 text-emerald-700 ring-1 ring-inset ring-emerald-200';
+    case 'RECHAZADO':
+      return 'bg-red-100 text-red-700 ring-1 ring-inset ring-red-200';
+    default:
+      return 'bg-amber-100 text-amber-700 ring-1 ring-inset ring-amber-200';
+  }
+}
+
 export default function CapturePage() {
+  const { profile } = useAuth();
   const [selectedIndicator, setSelectedIndicator] = useState(null);
+  const [editingMeasurement, setEditingMeasurement] = useState(null);
+  const [validatingMeasurementId, setValidatingMeasurementId] = useState(null);
   const currentYear = new Date().getFullYear();
+  const currentMonth = new Date().getMonth() + 1;
 
   const queryClient = useQueryClient();
   const indicatorsQuery = useQuery({ queryKey: ['indicators'], queryFn: getIndicators });
 
+  const roleLabel = (profile?.rol ?? profile?.puesto ?? '').toString().toLowerCase();
+  const isAdmin = roleLabel.includes('admin');
+  const isSubdirector = roleLabel.includes('subdirector');
+  const canValidate = isAdmin || isSubdirector;
+  const canManageTargets = isAdmin || isSubdirector;
+
+  const allowedAreaIds = useMemo(() => {
+    const ids = new Set();
+    if (profile?.area_id) ids.add(String(profile.area_id));
+    if (profile?.area?.id) ids.add(String(profile.area.id));
+    if (profile?.subdireccion_id) ids.add(String(profile.subdireccion_id));
+    return ids;
+  }, [profile]);
+
+  const filteredIndicators = useMemo(() => {
+    const data = indicatorsQuery.data ?? [];
+    if (!data.length) return [];
+    if (isAdmin) return data;
+    if (!allowedAreaIds.size) return data;
+    return data.filter(indicator => {
+      const ids = resolveIndicatorAreaIds(indicator);
+      if (!ids.size) return false;
+      return Array.from(ids).some(id => allowedAreaIds.has(id));
+    });
+  }, [indicatorsQuery.data, isAdmin, allowedAreaIds]);
+
   const indicatorsOptions = useMemo(
     () =>
-      (indicatorsQuery.data ?? []).map(item => ({
+      filteredIndicators.map(item => ({
         value: item.id,
         label: item.nombre,
-        area: item.area_nombre,
-        unidad: item.unidad_medida
+        area: resolveIndicatorAreaName(item),
+        unidad: resolveIndicatorUnit(item)
       })),
-    [indicatorsQuery.data]
+    [filteredIndicators]
   );
 
   useEffect(() => {
-    if (!selectedIndicator && indicatorsOptions.length) {
+    if (!indicatorsOptions.length) {
+      setSelectedIndicator(null);
+      return;
+    }
+    if (!selectedIndicator || !indicatorsOptions.some(option => option.value === selectedIndicator)) {
       setSelectedIndicator(indicatorsOptions[0].value);
     }
-  }, [selectedIndicator, indicatorsOptions]);
+  }, [indicatorsOptions, selectedIndicator]);
 
   const historyQuery = useQuery({
     queryKey: ['indicator-history', selectedIndicator],
@@ -73,7 +221,7 @@ export default function CapturePage() {
   const measurementForm = useForm({
     defaultValues: {
       anio: currentYear,
-      mes: new Date().getMonth() + 1,
+      mes: currentMonth,
       valor: '',
       escenario: 'REAL'
     }
@@ -82,53 +230,199 @@ export default function CapturePage() {
   const targetForm = useForm({
     defaultValues: {
       anio: currentYear,
-      mes: new Date().getMonth() + 1,
+      mes: currentMonth,
       escenario: 'MEDIO',
       valor: ''
     }
   });
 
-  const measurementMutation = useMutation({
+  const resetMeasurementForm = useCallback(() => {
+    measurementForm.reset({
+      anio: currentYear,
+      mes: new Date().getMonth() + 1,
+      valor: '',
+      escenario: 'REAL'
+    });
+  }, [measurementForm, currentYear]);
+
+  const resetTargetForm = useCallback(() => {
+    targetForm.reset({
+      anio: currentYear,
+      mes: new Date().getMonth() + 1,
+      escenario: 'MEDIO',
+      valor: ''
+    });
+  }, [targetForm, currentYear]);
+
+  useEffect(() => {
+    setEditingMeasurement(null);
+    resetMeasurementForm();
+    resetTargetForm();
+  }, [selectedIndicator, resetMeasurementForm, resetTargetForm]);
+
+  const createMeasurementMutation = useMutation({
     mutationFn: payload => saveMeasurement(payload),
-    onSuccess: () => {
-      measurementForm.reset({
-        anio: currentYear,
-        mes: new Date().getMonth() + 1,
-        valor: '',
-        escenario: 'REAL'
+    onSuccess: (_data, variables) => {
+      resetMeasurementForm();
+      queryClient.invalidateQueries({
+        queryKey: ['indicator-history', variables?.indicador_id ?? selectedIndicator]
       });
-      queryClient.invalidateQueries({ queryKey: ['indicator-history', selectedIndicator] });
+    }
+  });
+
+  const updateMeasurementMutation = useMutation({
+    mutationFn: ({ id, payload }) => updateMeasurement(id, payload),
+    onSuccess: (_data, variables) => {
+      setEditingMeasurement(null);
+      resetMeasurementForm();
+      queryClient.invalidateQueries({
+        queryKey: ['indicator-history', variables?.payload?.indicador_id ?? selectedIndicator]
+      });
+    }
+  });
+
+  const validateMeasurementMutation = useMutation({
+    mutationFn: ({ id, validado_por }) =>
+      validateMeasurement(id, { validado_por: validado_por ?? profile?.id ?? null }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ['indicator-history', variables?.indicador_id ?? selectedIndicator]
+      });
     }
   });
 
   const targetMutation = useMutation({
     mutationFn: payload => upsertTarget(payload),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['indicator-targets', selectedIndicator, currentYear] });
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ['indicator-targets', variables?.indicador_id ?? selectedIndicator, currentYear]
+      });
     }
   });
 
+  const handleEditMeasurement = item => {
+    setEditingMeasurement(item);
+    measurementForm.reset({
+      anio: item.anio ?? currentYear,
+      mes: item.mes ?? currentMonth,
+      valor: item.valor ?? '',
+      escenario: item.escenario ?? 'REAL'
+    });
+  };
+
+  const handleCancelEdit = () => {
+    setEditingMeasurement(null);
+    resetMeasurementForm();
+  };
+
+  const handleValidateMeasurement = item => {
+    if (!item?.id || !canValidate) return;
+    setValidatingMeasurementId(item.id);
+    validateMeasurementMutation.mutate(
+      { id: item.id, indicador_id: selectedIndicator, validado_por: profile?.id ?? null },
+      {
+        onSettled: () => {
+          setValidatingMeasurementId(null);
+        }
+      }
+    );
+  };
+
   const onSubmitMeasurement = measurementForm.handleSubmit(values => {
     if (!selectedIndicator) return;
-    measurementMutation.mutate({
+    const basePayload = {
       indicador_id: selectedIndicator,
       anio: Number(values.anio),
       mes: Number(values.mes),
       valor: Number(values.valor),
       escenario: values.escenario
+    };
+
+    if (editingMeasurement) {
+      if (!canValidate) return;
+      updateMeasurementMutation.mutate({
+        id: editingMeasurement.id,
+        payload: {
+          ...basePayload,
+          editado_por: profile?.id ?? null,
+          estatus_validacion: 'PENDIENTE',
+          validado_por: null,
+          fecha_validacion: null
+        }
+      });
+      return;
+    }
+
+    createMeasurementMutation.mutate({
+      ...basePayload,
+      capturado_por: profile?.id ?? null,
+      estatus_validacion: 'PENDIENTE'
     });
   });
 
   const onSubmitTarget = targetForm.handleSubmit(values => {
-    if (!selectedIndicator) return;
-    targetMutation.mutate({
-      indicador_id: selectedIndicator,
-      anio: Number(values.anio),
-      mes: Number(values.mes),
-      escenario: values.escenario,
-      valor: Number(values.valor)
+    if (!selectedIndicator || !canManageTargets) return;
+    const year = Number(values.anio);
+    const month = Number(values.mes);
+    const scenario = values.escenario;
+    const existing = (targetsQuery.data ?? []).find(target => {
+      return (
+        Number(target.anio) === year &&
+        Number(target.mes) === month &&
+        (target.escenario ?? '').toString().toUpperCase() === scenario
+      );
     });
+
+    const payload = {
+      indicador_id: selectedIndicator,
+      anio: year,
+      mes: month,
+      escenario: scenario,
+      valor: Number(values.valor)
+    };
+
+    if (existing?.id) {
+      payload.id = existing.id;
+      payload.editado_por = profile?.id ?? null;
+    } else {
+      payload.capturado_por = profile?.id ?? null;
+    }
+
+    targetMutation.mutate(payload);
   });
+
+  const measurementIsSubmitting =
+    createMeasurementMutation.isPending || updateMeasurementMutation.isPending;
+  const measurementError = createMeasurementMutation.error ?? updateMeasurementMutation.error;
+  const measurementSuccessMessage = useMemo(() => {
+    if (createMeasurementMutation.isSuccess) {
+      return 'Medición registrada correctamente y enviada a validación.';
+    }
+    if (updateMeasurementMutation.isSuccess) {
+      return 'Medición actualizada; se requiere una nueva validación.';
+    }
+    return null;
+  }, [createMeasurementMutation.isSuccess, updateMeasurementMutation.isSuccess]);
+
+  const validationError = validateMeasurementMutation.error;
+  const validationSuccessMessage = validateMeasurementMutation.isSuccess
+    ? 'Medición validada correctamente.'
+    : null;
+
+  const targetError = targetMutation.error;
+  const targetSuccessMessage = targetMutation.isSuccess ? 'Meta registrada correctamente.' : null;
+
+  const indicatorsLoading = indicatorsQuery.isLoading;
+  const indicatorsError = indicatorsQuery.isError;
+  const noIndicatorsAssigned = indicatorsQuery.isSuccess && !indicatorsOptions.length;
+
+  const assignedAreaName =
+    profile?.area?.nombre ??
+    profile?.area_nombre ??
+    (profile?.area_id ? `Área ${profile.area_id}` : null);
+
+  const historyData = historyQuery.data ?? [];
+  const targetsData = targetsQuery.data ?? [];
 
   return (
     <div className="space-y-6">
@@ -138,252 +432,432 @@ export default function CapturePage() {
           <p className="text-sm text-slate-500">
             Actualice mediciones reales y metas estratégicas para mantener el panel de directivos siempre vigente.
           </p>
+          {assignedAreaName && (
+            <p className="text-xs text-slate-400">Área asignada: {assignedAreaName}</p>
+          )}
         </div>
       </header>
 
-      <section className="rounded-2xl bg-white p-6 shadow">
-        <label className="block">
-          <span className="text-xs font-semibold uppercase tracking-widest text-slate-400">Indicador</span>
-          <select
-            value={selectedIndicator ?? ''}
-            onChange={event => setSelectedIndicator(event.target.value)}
-            className="mt-2 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-aifa-blue focus:outline-none focus:ring-2 focus:ring-aifa-blue/30"
-          >
-            {indicatorsOptions.map(option => (
-              <option key={option.value} value={option.value}>
-                {option.label} — {option.area}
-              </option>
-            ))}
-          </select>
-        </label>
-        {selectedIndicator && (
-          <p className="mt-2 text-xs text-slate-500">
-            Unidad de medida:{' '}
-            <span className="font-semibold text-slate-700">
-              {indicatorsOptions.find(option => option.value === selectedIndicator)?.unidad ?? 'No definida'}
-            </span>
-          </p>
-        )}
-      </section>
-
-      <div className="grid gap-6 lg:grid-cols-2">
-        <SectionCard
-          title="Registrar medición"
-          description="Capture el valor real observado para el periodo seleccionado."
-          icon={PlusCircle}
-        >
-          <form onSubmit={onSubmitMeasurement} className="grid gap-4 sm:grid-cols-2">
-            <label className="flex flex-col gap-1 text-sm">
-              Año
-              <input
-                type="number"
-                min="2020"
-                max="2100"
-                {...measurementForm.register('anio', { required: true })}
-                className="rounded-lg border border-slate-200 px-3 py-2 shadow-sm focus:border-aifa-blue focus:outline-none focus:ring-2 focus:ring-aifa-blue/30"
-              />
-            </label>
-            <label className="flex flex-col gap-1 text-sm">
-              Mes
-              <select
-                {...measurementForm.register('mes', { required: true })}
-                className="rounded-lg border border-slate-200 px-3 py-2 shadow-sm focus:border-aifa-blue focus:outline-none focus:ring-2 focus:ring-aifa-blue/30"
-              >
-                {Array.from({ length: 12 }, (_, index) => index + 1).map(month => (
-                  <option key={month} value={month}>
-                    {formatMonth(currentYear, month)}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <label className="flex flex-col gap-1 text-sm">
-              Escenario
-              <select
-                {...measurementForm.register('escenario', { required: true })}
-                className="rounded-lg border border-slate-200 px-3 py-2 shadow-sm focus:border-aifa-blue focus:outline-none focus:ring-2 focus:ring-aifa-blue/30"
-              >
-                <option value="REAL">Valor real</option>
-                {SCENARIOS.map(option => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <label className="flex flex-col gap-1 text-sm sm:col-span-2">
-              Valor
-              <input
-                type="number"
-                step="0.01"
-                {...measurementForm.register('valor', { required: true, min: 0 })}
-                className="rounded-lg border border-slate-200 px-3 py-2 shadow-sm focus:border-aifa-blue focus:outline-none focus:ring-2 focus:ring-aifa-blue/30"
-              />
-            </label>
-            <div className="sm:col-span-2">
-              <button
-                type="submit"
-                className="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-aifa-blue px-4 py-2 text-sm font-semibold text-white shadow hover:bg-aifa-light focus:outline-none focus:ring-2 focus:ring-aifa-blue/30 disabled:cursor-not-allowed"
-                disabled={measurementMutation.isPending}
-              >
-                {measurementMutation.isPending ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  <CheckCircle2 className="h-4 w-4" />
-                )}
-                Guardar medición
-              </button>
-              {measurementMutation.isError && (
-                <p className="mt-2 text-xs text-red-500">
-                  No fue posible guardar la medición: {measurementMutation.error.message}
-                </p>
-              )}
-              {measurementMutation.isSuccess && (
-                <p className="mt-2 text-xs text-green-600">Medición registrada correctamente.</p>
-              )}
-            </div>
-          </form>
-        </SectionCard>
-
-        <SectionCard
-          title="Actualizar meta"
-          description="Registre la meta del indicador para el periodo seleccionado en el escenario deseado."
-          icon={Target}
-        >
-          <form onSubmit={onSubmitTarget} className="grid gap-4 sm:grid-cols-2">
-            <label className="flex flex-col gap-1 text-sm">
-              Año
-              <input
-                type="number"
-                min="2020"
-                max="2100"
-                {...targetForm.register('anio', { required: true })}
-                className="rounded-lg border border-slate-200 px-3 py-2 shadow-sm focus:border-aifa-blue focus:outline-none focus:ring-2 focus:ring-aifa-blue/30"
-              />
-            </label>
-            <label className="flex flex-col gap-1 text-sm">
-              Mes
-              <select
-                {...targetForm.register('mes', { required: true })}
-                className="rounded-lg border border-slate-200 px-3 py-2 shadow-sm focus:border-aifa-blue focus:outline-none focus:ring-2 focus:ring-aifa-blue/30"
-              >
-                {Array.from({ length: 12 }, (_, index) => index + 1).map(month => (
-                  <option key={month} value={month}>
-                    {formatMonth(currentYear, month)}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <label className="flex flex-col gap-1 text-sm">
-              Escenario
-              <select
-                {...targetForm.register('escenario', { required: true })}
-                className="rounded-lg border border-slate-200 px-3 py-2 shadow-sm focus:border-aifa-blue focus:outline-none focus:ring-2 focus:ring-aifa-blue/30"
-              >
-                {SCENARIOS.map(option => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <label className="flex flex-col gap-1 text-sm sm:col-span-2">
-              Valor meta
-              <input
-                type="number"
-                step="0.01"
-                {...targetForm.register('valor', { required: true, min: 0 })}
-                className="rounded-lg border border-slate-200 px-3 py-2 shadow-sm focus:border-aifa-blue focus:outline-none focus:ring-2 focus:ring-aifa-blue/30"
-              />
-            </label>
-            <div className="sm:col-span-2">
-              <button
-                type="submit"
-                className="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-aifa-green px-4 py-2 text-sm font-semibold text-white shadow hover:bg-emerald-600 focus:outline-none focus:ring-2 focus:ring-aifa-green/30 disabled:cursor-not-allowed"
-                disabled={targetMutation.isPending}
-              >
-                {targetMutation.isPending ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  <CheckCircle2 className="h-4 w-4" />
-                )}
-                Guardar meta
-              </button>
-              {targetMutation.isError && (
-                <p className="mt-2 text-xs text-red-500">
-                  No fue posible guardar la meta: {targetMutation.error.message}
-                </p>
-              )}
-              {targetMutation.isSuccess && (
-                <p className="mt-2 text-xs text-green-600">Meta registrada correctamente.</p>
-              )}
-            </div>
-          </form>
-        </SectionCard>
-      </div>
-
-      <div className="grid gap-6 lg:grid-cols-2">
+      {indicatorsLoading && (
         <section className="rounded-2xl bg-white p-6 shadow">
-          <h3 className="text-sm font-semibold uppercase tracking-widest text-slate-400">Mediciones recientes</h3>
-          <div className="mt-4 overflow-hidden rounded-xl border border-slate-100">
-            <table className="min-w-full divide-y divide-slate-200 text-sm">
-              <thead className="bg-slate-50 text-xs uppercase tracking-widest text-slate-500">
-                <tr>
-                  <th className="px-4 py-2 text-left">Periodo</th>
-                  <th className="px-4 py-2 text-left">Escenario</th>
-                  <th className="px-4 py-2 text-right">Valor</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-slate-100">
-                {(historyQuery.data ?? []).map(item => (
-                  <tr key={item.id} className="hover:bg-slate-50/80">
-                    <td className="px-4 py-2 text-slate-600">{formatMonth(item.anio, item.mes ?? 1)}</td>
-                    <td className="px-4 py-2 text-slate-500">{item.escenario ?? 'REAL'}</td>
-                    <td className="px-4 py-2 text-right font-medium text-slate-800">{formatNumber(item.valor)}</td>
-                  </tr>
-                ))}
-                {!historyQuery.data?.length && (
-                  <tr>
-                    <td colSpan={3} className="px-4 py-6 text-center text-slate-400">
-                      Sin mediciones registradas.
-                    </td>
-                  </tr>
-                )}
-              </tbody>
-            </table>
+          <div className="flex items-center gap-3 text-sm text-slate-500">
+            <Loader2 className="h-4 w-4 animate-spin" /> Cargando indicadores disponibles...
           </div>
         </section>
+      )}
 
-        <section className="rounded-2xl bg-white p-6 shadow">
-          <h3 className="text-sm font-semibold uppercase tracking-widest text-slate-400">Metas del año</h3>
-          <div className="mt-4 overflow-hidden rounded-xl border border-slate-100">
-            <table className="min-w-full divide-y divide-slate-200 text-sm">
-              <thead className="bg-slate-50 text-xs uppercase tracking-widest text-slate-500">
-                <tr>
-                  <th className="px-4 py-2 text-left">Periodo</th>
-                  <th className="px-4 py-2 text-left">Escenario</th>
-                  <th className="px-4 py-2 text-right">Meta</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-slate-100">
-                {(targetsQuery.data ?? []).map(item => (
-                  <tr key={item.id ?? `${item.anio}-${item.mes}-${item.escenario}`} className="hover:bg-slate-50/80">
-                    <td className="px-4 py-2 text-slate-600">{formatMonth(item.anio, item.mes)}</td>
-                    <td className="px-4 py-2 text-slate-500">{item.escenario}</td>
-                    <td className="px-4 py-2 text-right font-medium text-slate-800">{formatNumber(item.valor)}</td>
-                  </tr>
-                ))}
-                {!targetsQuery.data?.length && (
-                  <tr>
-                    <td colSpan={3} className="px-4 py-6 text-center text-slate-400">
-                      No hay metas registradas para este año.
-                    </td>
-                  </tr>
-                )}
-              </tbody>
-            </table>
-          </div>
+      {indicatorsError && (
+        <section className="rounded-2xl border border-red-200 bg-red-50 p-6 text-sm text-red-700 shadow">
+          No fue posible obtener los indicadores configurados para el sistema.
         </section>
-      </div>
+      )}
+
+      {!indicatorsLoading && !indicatorsError && (
+        <section className="rounded-2xl bg-white p-6 shadow">
+          <label className="block">
+            <span className="text-xs font-semibold uppercase tracking-widest text-slate-400">Indicador</span>
+            <select
+              value={selectedIndicator ?? ''}
+              onChange={event => setSelectedIndicator(event.target.value)}
+              className="mt-2 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-aifa-blue focus:outline-none focus:ring-2 focus:ring-aifa-blue/30"
+              disabled={!indicatorsOptions.length}
+            >
+              {indicatorsOptions.map(option => (
+                <option key={option.value} value={option.value}>
+                  {option.label} — {option.area}
+                </option>
+              ))}
+            </select>
+          </label>
+          {selectedIndicator && (
+            <p className="mt-2 text-xs text-slate-500">
+              Unidad de medida:{' '}
+              <span className="font-semibold text-slate-700">
+                {indicatorsOptions.find(option => option.value === selectedIndicator)?.unidad ?? 'No definida'}
+              </span>
+            </p>
+          )}
+          {noIndicatorsAssigned && (
+            <div className="mt-4 rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-700">
+              No cuentas con indicadores asignados para captura en tu área. Solicita apoyo a tu administrador.
+            </div>
+          )}
+        </section>
+      )}
+
+      {!selectedIndicator && !indicatorsLoading && (
+        <section className="rounded-2xl border border-amber-200 bg-amber-50 p-6 text-sm text-amber-700 shadow">
+          Selecciona un indicador para comenzar la captura. Si no tienes permisos, contacta al administrador del sistema.
+        </section>
+      )}
+
+      {selectedIndicator && (
+        <>
+          <div className="grid gap-6 lg:grid-cols-2">
+            <SectionCard
+              title={editingMeasurement ? 'Editar medición' : 'Registrar medición'}
+              description={
+                editingMeasurement
+                  ? 'Actualiza el valor registrado. Una vez guardado, la medición deberá ser validada nuevamente.'
+                  : 'Capture el valor real observado para el periodo seleccionado. La medición quedará pendiente de validación.'
+              }
+              icon={PlusCircle}
+            >
+              <form onSubmit={onSubmitMeasurement} className="grid gap-4 sm:grid-cols-2">
+                <label className="flex flex-col gap-1 text-sm">
+                  Año
+                  <input
+                    type="number"
+                    min="2020"
+                    max="2100"
+                    {...measurementForm.register('anio', { required: true })}
+                    className="rounded-lg border border-slate-200 px-3 py-2 shadow-sm focus:border-aifa-blue focus:outline-none focus:ring-2 focus:ring-aifa-blue/30"
+                  />
+                </label>
+                <label className="flex flex-col gap-1 text-sm">
+                  Mes
+                  <select
+                    {...measurementForm.register('mes', { required: true })}
+                    className="rounded-lg border border-slate-200 px-3 py-2 shadow-sm focus:border-aifa-blue focus:outline-none focus:ring-2 focus:ring-aifa-blue/30"
+                  >
+                    {Array.from({ length: 12 }, (_, index) => index + 1).map(month => (
+                      <option key={month} value={month}>
+                        {formatMonth(currentYear, month)}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="flex flex-col gap-1 text-sm">
+                  Escenario
+                  <select
+                    {...measurementForm.register('escenario', { required: true })}
+                    className="rounded-lg border border-slate-200 px-3 py-2 shadow-sm focus:border-aifa-blue focus:outline-none focus:ring-2 focus:ring-aifa-blue/30"
+                  >
+                    <option value="REAL">Valor real</option>
+                    {SCENARIOS.map(option => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="flex flex-col gap-1 text-sm sm:col-span-2">
+                  Valor
+                  <input
+                    type="number"
+                    step="0.01"
+                    {...measurementForm.register('valor', { required: true, min: 0 })}
+                    className="rounded-lg border border-slate-200 px-3 py-2 shadow-sm focus:border-aifa-blue focus:outline-none focus:ring-2 focus:ring-aifa-blue/30"
+                  />
+                </label>
+                <div className="flex flex-col gap-3 sm:col-span-2">
+                  <div className="flex flex-wrap gap-3">
+                    <button
+                      type="submit"
+                      className="inline-flex items-center justify-center gap-2 rounded-lg bg-aifa-blue px-4 py-2 text-sm font-semibold text-white shadow hover:bg-aifa-light focus:outline-none focus:ring-2 focus:ring-aifa-blue/30 disabled:cursor-not-allowed disabled:opacity-70"
+                      disabled={measurementIsSubmitting}
+                    >
+                      {measurementIsSubmitting ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : (
+                        <CheckCircle2 className="h-4 w-4" />
+                      )}
+                      {editingMeasurement ? 'Actualizar medición' : 'Guardar medición'}
+                    </button>
+                    {editingMeasurement && (
+                      <button
+                        type="button"
+                        onClick={handleCancelEdit}
+                        className="inline-flex items-center justify-center gap-2 rounded-lg border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 shadow-sm hover:border-aifa-blue hover:text-aifa-blue focus:outline-none focus:ring-2 focus:ring-aifa-blue/30"
+                        disabled={measurementIsSubmitting}
+                      >
+                        <Undo2 className="h-4 w-4" /> Cancelar edición
+                      </button>
+                    )}
+                  </div>
+                  {measurementError && (
+                    <p className="text-xs text-red-500">
+                      No fue posible guardar la medición: {measurementError.message ?? measurementError.toString()}
+                    </p>
+                  )}
+                  {measurementSuccessMessage && (
+                    <p className="text-xs text-emerald-600">{measurementSuccessMessage}</p>
+                  )}
+                </div>
+              </form>
+            </SectionCard>
+
+            <SectionCard
+              title="Actualizar meta"
+              description={
+                canManageTargets
+                  ? 'Registre la meta del indicador para el periodo seleccionado en el escenario deseado.'
+                  : 'Solo el subdirector del área o un administrador pueden actualizar las metas por escenario.'
+              }
+              icon={Target}
+            >
+              <form onSubmit={onSubmitTarget} className="grid gap-4 sm:grid-cols-2">
+                <label className="flex flex-col gap-1 text-sm">
+                  Año
+                  <input
+                    type="number"
+                    min="2020"
+                    max="2100"
+                    {...targetForm.register('anio', { required: true })}
+                    className="rounded-lg border border-slate-200 px-3 py-2 shadow-sm focus:border-aifa-blue focus:outline-none focus:ring-2 focus:ring-aifa-blue/30"
+                    disabled={!canManageTargets}
+                  />
+                </label>
+                <label className="flex flex-col gap-1 text-sm">
+                  Mes
+                  <select
+                    {...targetForm.register('mes', { required: true })}
+                    className="rounded-lg border border-slate-200 px-3 py-2 shadow-sm focus:border-aifa-blue focus:outline-none focus:ring-2 focus:ring-aifa-blue/30"
+                    disabled={!canManageTargets}
+                  >
+                    {Array.from({ length: 12 }, (_, index) => index + 1).map(month => (
+                      <option key={month} value={month}>
+                        {formatMonth(currentYear, month)}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="flex flex-col gap-1 text-sm">
+                  Escenario
+                  <select
+                    {...targetForm.register('escenario', { required: true })}
+                    className="rounded-lg border border-slate-200 px-3 py-2 shadow-sm focus:border-aifa-blue focus:outline-none focus:ring-2 focus:ring-aifa-blue/30"
+                    disabled={!canManageTargets}
+                  >
+                    {SCENARIOS.map(option => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="flex flex-col gap-1 text-sm sm:col-span-2">
+                  Valor meta
+                  <input
+                    type="number"
+                    step="0.01"
+                    {...targetForm.register('valor', { required: true, min: 0 })}
+                    className="rounded-lg border border-slate-200 px-3 py-2 shadow-sm focus:border-aifa-blue focus:outline-none focus:ring-2 focus:ring-aifa-blue/30"
+                    disabled={!canManageTargets}
+                  />
+                </label>
+                <div className="flex flex-col gap-2 sm:col-span-2">
+                  <button
+                    type="submit"
+                    className="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-aifa-green px-4 py-2 text-sm font-semibold text-white shadow hover:bg-emerald-600 focus:outline-none focus:ring-2 focus:ring-aifa-green/30 disabled:cursor-not-allowed disabled:opacity-70"
+                    disabled={targetMutation.isPending || !canManageTargets}
+                  >
+                    {targetMutation.isPending ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <BadgeCheck className="h-4 w-4" />
+                    )}
+                    Guardar meta
+                  </button>
+                  {!canManageTargets && (
+                    <p className="text-xs text-slate-500">
+                      Solo los subdirectores de área y administradores pueden editar metas por escenario.
+                    </p>
+                  )}
+                  {targetError && (
+                    <p className="text-xs text-red-500">
+                      No fue posible guardar la meta: {targetError.message ?? targetError.toString()}
+                    </p>
+                  )}
+                  {targetSuccessMessage && (
+                    <p className="text-xs text-emerald-600">{targetSuccessMessage}</p>
+                  )}
+                </div>
+              </form>
+            </SectionCard>
+          </div>
+
+          <div className="grid gap-6 lg:grid-cols-2">
+            <section className="rounded-2xl bg-white p-6 shadow">
+              <div className="flex items-start justify-between gap-3">
+                <h3 className="text-sm font-semibold uppercase tracking-widest text-slate-400">Mediciones recientes</h3>
+                {validationSuccessMessage && (
+                  <span className="text-xs font-semibold text-emerald-600">{validationSuccessMessage}</span>
+                )}
+              </div>
+              {validationError && (
+                <p className="mt-2 text-xs text-red-500">
+                  No fue posible validar la medición: {validationError.message ?? validationError.toString()}
+                </p>
+              )}
+              {historyQuery.isError && (
+                <p className="mt-2 text-xs text-red-500">No fue posible cargar el histórico de mediciones.</p>
+              )}
+              <div className="mt-4 overflow-hidden rounded-xl border border-slate-100">
+                {historyQuery.isLoading ? (
+                  <div className="flex items-center gap-2 px-4 py-6 text-sm text-slate-500">
+                    <Loader2 className="h-4 w-4 animate-spin" /> Consultando mediciones...
+                  </div>
+                ) : (
+                  <table className="min-w-full divide-y divide-slate-200 text-sm">
+                    <thead className="bg-slate-50 text-xs uppercase tracking-widest text-slate-500">
+                      <tr>
+                        <th className="px-4 py-2 text-left">Periodo</th>
+                        <th className="px-4 py-2 text-left">Escenario</th>
+                        <th className="px-4 py-2 text-right">Valor</th>
+                        <th className="px-4 py-2 text-left">Estado</th>
+                        {canValidate && <th className="px-4 py-2 text-left">Acciones</th>}
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-slate-100">
+                      {historyData.map(item => {
+                        const status = computeValidationStatus(item);
+                        const statusLabel = VALIDATION_LABELS[status] ?? status;
+                        const isValidated = status === 'VALIDADO';
+                        const isPending = status === 'PENDIENTE';
+                        return (
+                          <tr
+                            key={item.id ?? `${item.anio}-${item.mes}-${item.escenario ?? 'REAL'}`}
+                            className={`transition hover:bg-slate-50/80 ${
+                              editingMeasurement?.id === item.id ? 'bg-slate-50' : ''
+                            }`}
+                          >
+                            <td className="px-4 py-2 text-slate-600">{formatMonth(item.anio, item.mes ?? 1)}</td>
+                            <td className="px-4 py-2 text-slate-500">{item.escenario ?? 'REAL'}</td>
+                            <td className="px-4 py-2 text-right font-medium text-slate-800">{formatNumber(item.valor)}</td>
+                            <td className="px-4 py-2">
+                              <div className="flex flex-col gap-1">
+                                <span
+                                  className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-[11px] font-semibold ${getStatusBadgeClass(
+                                    status
+                                  )}`}
+                                >
+                                  {isValidated ? (
+                                    <BadgeCheck className="h-3.5 w-3.5" />
+                                  ) : (
+                                    <Clock className="h-3.5 w-3.5" />
+                                  )}
+                                  {statusLabel}
+                                </span>
+                                <p className="text-xs text-slate-400">
+                                  {isValidated && item.fecha_validacion
+                                    ? `Validado el ${formatDate(item.fecha_validacion)}`
+                                    : `Actualizado el ${formatDate(item.fecha_actualizacion ?? item.fecha_captura)}`}
+                                </p>
+                                {item.capturado_por && (
+                                  <p className="text-[11px] text-slate-300">Capturado por: {item.capturado_por}</p>
+                                )}
+                                {item.editado_por && !isValidated && (
+                                  <p className="text-[11px] text-slate-300">Última edición por: {item.editado_por}</p>
+                                )}
+                              </div>
+                            </td>
+                            {canValidate && (
+                              <td className="px-4 py-2">
+                                <div className="flex flex-wrap gap-2">
+                                  <button
+                                    type="button"
+                                    onClick={() => handleEditMeasurement(item)}
+                                    className="inline-flex items-center gap-2 rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-semibold text-slate-600 transition hover:border-aifa-blue hover:text-aifa-blue focus:outline-none focus:ring-2 focus:ring-aifa-blue/30 disabled:cursor-not-allowed disabled:opacity-60"
+                                    disabled={
+                                      measurementIsSubmitting ||
+                                      (editingMeasurement?.id === item.id && updateMeasurementMutation.isPending)
+                                    }
+                                  >
+                                    <PencilLine className="h-3.5 w-3.5" /> Editar
+                                  </button>
+                                  {!isValidated && (
+                                    <button
+                                      type="button"
+                                      onClick={() => handleValidateMeasurement(item)}
+                                      className="inline-flex items-center gap-2 rounded-lg border border-emerald-200 px-3 py-1.5 text-xs font-semibold text-emerald-700 transition hover:border-emerald-400 hover:text-emerald-800 focus:outline-none focus:ring-2 focus:ring-emerald-200/60 disabled:cursor-not-allowed disabled:opacity-60"
+                                      disabled={validateMeasurementMutation.isPending}
+                                    >
+                                      {validateMeasurementMutation.isPending && validatingMeasurementId === item.id ? (
+                                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                                      ) : (
+                                        <ShieldCheck className="h-3.5 w-3.5" />
+                                      )}
+                                      Validar
+                                    </button>
+                                  )}
+                                </div>
+                              </td>
+                            )}
+                          </tr>
+                        );
+                      })}
+                      {!historyData.length && !historyQuery.isLoading && (
+                        <tr>
+                          <td
+                            colSpan={canValidate ? 5 : 4}
+                            className="px-4 py-6 text-center text-slate-400"
+                          >
+                            Sin mediciones registradas.
+                          </td>
+                        </tr>
+                      )}
+                    </tbody>
+                  </table>
+                )}
+              </div>
+            </section>
+
+            <section className="rounded-2xl bg-white p-6 shadow">
+              <h3 className="text-sm font-semibold uppercase tracking-widest text-slate-400">Metas del año</h3>
+              {targetsQuery.isError && (
+                <p className="mt-2 text-xs text-red-500">No fue posible consultar las metas registradas.</p>
+              )}
+              <div className="mt-4 overflow-hidden rounded-xl border border-slate-100">
+                {targetsQuery.isLoading ? (
+                  <div className="flex items-center gap-2 px-4 py-6 text-sm text-slate-500">
+                    <Loader2 className="h-4 w-4 animate-spin" /> Cargando metas...
+                  </div>
+                ) : (
+                  <table className="min-w-full divide-y divide-slate-200 text-sm">
+                    <thead className="bg-slate-50 text-xs uppercase tracking-widest text-slate-500">
+                      <tr>
+                        <th className="px-4 py-2 text-left">Periodo</th>
+                        <th className="px-4 py-2 text-left">Escenario</th>
+                        <th className="px-4 py-2 text-right">Meta</th>
+                        <th className="px-4 py-2 text-left">Actualización</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-slate-100">
+                      {targetsData.map(item => (
+                        <tr key={item.id ?? `${item.anio}-${item.mes}-${item.escenario}`} className="hover:bg-slate-50/80">
+                          <td className="px-4 py-2 text-slate-600">{formatMonth(item.anio, item.mes)}</td>
+                          <td className="px-4 py-2 text-slate-500">{item.escenario}</td>
+                          <td className="px-4 py-2 text-right font-medium text-slate-800">{formatNumber(item.valor)}</td>
+                          <td className="px-4 py-2 text-slate-500">
+                            <p className="text-xs text-slate-500">
+                              {formatDate(item.fecha_actualizacion ?? item.fecha_captura)}
+                            </p>
+                            {item.editado_por ? (
+                              <p className="text-[11px] text-slate-300">Editado por: {item.editado_por}</p>
+                            ) : (
+                              item.capturado_por && (
+                                <p className="text-[11px] text-slate-300">Capturado por: {item.capturado_por}</p>
+                              )
+                            )}
+                          </td>
+                        </tr>
+                      ))}
+                      {!targetsData.length && !targetsQuery.isLoading && (
+                        <tr>
+                          <td colSpan={4} className="px-4 py-6 text-center text-slate-400">
+                            No hay metas registradas para este año.
+                          </td>
+                        </tr>
+                      )}
+                    </tbody>
+                  </table>
+                )}
+              </div>
+            </section>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/src/services/supabaseClient.js
+++ b/src/services/supabaseClient.js
@@ -29,12 +29,29 @@ function normalizeStatus(value) {
 
 function normalizeMeasurement(record) {
   if (!record) return record;
+  const status =
+    record.estatus_validacion ??
+    record.estado_validacion ??
+    record.estatus ??
+    (typeof record.validado === 'boolean'
+      ? record.validado
+        ? 'VALIDADO'
+        : 'PENDIENTE'
+      : null);
+
   return {
     ...record,
     escenario: record.escenario ? record.escenario.toUpperCase() : null,
+    estatus_validacion: typeof status === 'string' ? status.toUpperCase() : status ?? 'PENDIENTE',
     fecha_captura: record.fecha_captura ?? record.creado_en ?? null,
     fecha_actualizacion:
-      record.fecha_actualizacion ?? record.fecha_ultima_edicion ?? record.actualizado_en ?? null
+      record.fecha_actualizacion ?? record.fecha_ultima_edicion ?? record.actualizado_en ?? null,
+    fecha_validacion: record.fecha_validacion ?? record.validado_en ?? null,
+    validado_por: record.validado_por ?? record.subdirector_id ?? null,
+    observaciones_validacion:
+      record.observaciones_validacion ?? record.validacion_observaciones ?? null,
+    capturado_por: record.capturado_por ?? record.creado_por ?? null,
+    editado_por: record.editado_por ?? record.actualizado_por ?? null
   };
 }
 
@@ -45,7 +62,9 @@ function normalizeTarget(record) {
     escenario: record.escenario ? record.escenario.toUpperCase() : null,
     fecha_captura: record.fecha_captura ?? record.creado_en ?? null,
     fecha_actualizacion:
-      record.fecha_actualizacion ?? record.fecha_ultima_edicion ?? record.actualizado_en ?? null
+      record.fecha_actualizacion ?? record.fecha_ultima_edicion ?? record.actualizado_en ?? null,
+    capturado_por: record.capturado_por ?? record.creado_por ?? null,
+    editado_por: record.editado_por ?? record.actualizado_por ?? null
   };
 }
 
@@ -291,14 +310,23 @@ export async function getIndicatorTargets(indicadorId, { year } = {}) {
 }
 
 export async function saveMeasurement(payload) {
-  const sanitized = sanitizeScenario(payload);
+  const sanitized = sanitizeScenario(payload ? { ...payload } : payload);
+  if (sanitized && !('estatus_validacion' in sanitized)) {
+    sanitized.estatus_validacion = 'PENDIENTE';
+  }
+  if (sanitized && typeof sanitized.estatus_validacion === 'string') {
+    sanitized.estatus_validacion = sanitized.estatus_validacion.toUpperCase();
+  }
   const { data, error } = await supabase.from('mediciones').insert(sanitized).select().single();
   if (error) throw error;
   return normalizeMeasurement(data);
 }
 
 export async function updateMeasurement(id, payload) {
-  const sanitized = sanitizeScenario(payload);
+  const sanitized = sanitizeScenario(payload ? { ...payload } : payload);
+  if (sanitized && typeof sanitized.estatus_validacion === 'string') {
+    sanitized.estatus_validacion = sanitized.estatus_validacion.toUpperCase();
+  }
   const { data, error } = await supabase
     .from('mediciones')
     .update(sanitized)
@@ -307,6 +335,19 @@ export async function updateMeasurement(id, payload) {
     .single();
   if (error) throw error;
   return normalizeMeasurement(data);
+}
+
+export async function validateMeasurement(id, { validado_por, observaciones = null } = {}) {
+  if (!id) throw new Error('Se requiere un identificador de medición para validar.');
+  const payload = {
+    estatus_validacion: 'VALIDADO',
+    validado_por: validado_por ?? null,
+    fecha_validacion: new Date().toISOString()
+  };
+  if (observaciones !== undefined) {
+    payload.observaciones_validacion = observaciones;
+  }
+  return updateMeasurement(id, payload);
 }
 
 export async function upsertTarget(payload) {


### PR DESCRIPTION
## Summary
- fetch extended area metadata when building the authenticated profile so capture permissions can be enforced
- normalize measurement validation state, add a validation helper, and keep capture metadata in both Supabase client layers
- redesign the capture page with area-based filtering, edit/validation flows, and restrict target capture to subdirectors/administrators
- add SQL safeguards for mediciones control columns and a change log trigger for auditing updates

## Testing
- npm run build *(fails: vite CLI not available because dependencies cannot be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc569413f0832e811740746c5b3507