### PR TITLE
Allow admin creation of user profiles from modal

### DIFF
--- a/src/services/supabaseClient.js
+++ b/src/services/supabaseClient.js
@@ -1140,7 +1140,9 @@ export async function getAllUsers() {
   const { data: usuariosAreas, error: areasError } = await supabase
     .from('usuario_areas')
     .select(`
+      id,
       usuario_id,
+      area_id,
       rol,
       puede_capturar,
       puede_editar,
@@ -1175,21 +1177,23 @@ export async function getAllUsers() {
 /**
  * Crear nuevo usuario
  */
-export async function createUser({ email, password, nombre_completo, puesto, rol_principal, telefono }) {
-  // 1. Crear usuario en Supabase Auth (requiere permisos de admin)
-  // NOTA: Esto normalmente se hace desde una función del servidor (Edge Function)
-  // Por ahora solo creamos el perfil, el admin debe crear el usuario Auth manualmente
-  
+export async function createUser({ id, email, nombre_completo, puesto, rol_principal, telefono }) {
+  const payload = {
+    email,
+    nombre_completo,
+    puesto,
+    rol_principal,
+    telefono,
+    estado: 'ACTIVO'
+  };
+
+  if (id) {
+    payload.id = id;
+  }
+
   const { data, error } = await supabase
     .from('perfiles')
-    .insert({
-      email,
-      nombre_completo,
-      puesto,
-      rol_principal,
-      telefono,
-      estado: 'ACTIVO'
-    })
+    .insert(payload)
     .select()
     .single();
 

--- a/src/views/capture.js
+++ b/src/views/capture.js
@@ -4,6 +4,8 @@ import {
   getIndicatorHistory,
   getIndicatorTargets,
   saveMeasurement,
+  updateMeasurement,
+  validateMeasurement,
   upsertTarget
 } from '../services/supabaseClient.js';
 import { renderLoading, renderError, showToast } from '../ui/feedback.js';
@@ -23,7 +25,31 @@ let selectedAreaId = null;
 let selectedIndicatorId = null;
 let currentYear = new Date().getFullYear();
 
-function buildHistoryTable(history) {
+function formatValidationStatus(status) {
+  if (!status) return 'Pendiente';
+  const normalized = status.toString().trim().toUpperCase();
+  switch (normalized) {
+    case 'VALIDADO':
+      return 'Validado';
+    case 'RECHAZADO':
+      return 'Rechazado';
+    default:
+      return 'Pendiente';
+  }
+}
+
+function getStatusBadgeClass(status) {
+  switch ((status ?? '').toString().toUpperCase()) {
+    case 'VALIDADO':
+      return 'bg-emerald-100 text-emerald-700 border-emerald-200';
+    case 'RECHAZADO':
+      return 'bg-red-100 text-red-600 border-red-200';
+    default:
+      return 'bg-amber-100 text-amber-700 border-amber-200';
+  }
+}
+
+function buildHistoryTable(history, { showValidation = false } = {}) {
   if (!history.length) {
     return `
       <div class="bg-slate-50 border border-dashed border-slate-200 rounded-xl p-6 text-center text-sm text-slate-500">
@@ -49,17 +75,48 @@ function buildHistoryTable(history) {
             <th class="px-4 py-3 text-right font-semibold text-slate-500">Valor</th>
             <th class="px-4 py-3 text-left font-semibold text-slate-500">Escenario</th>
             <th class="px-4 py-3 text-right font-semibold text-slate-500">Capturado</th>
+            <th class="px-4 py-3 text-left font-semibold text-slate-500">Estatus</th>
+            ${showValidation ? '<th class="px-4 py-3 text-right font-semibold text-slate-500">Acciones</th>' : ''}
           </tr>
         </thead>
         <tbody class="divide-y divide-slate-100">
           ${sortedHistory
             .map((item) => {
+              const status = (item.estatus_validacion ?? '').toString().toUpperCase();
+              const badgeClass = getStatusBadgeClass(status);
+              const statusLabel = formatValidationStatus(status);
+              const canValidate = showValidation && status !== 'VALIDADO';
               return `
                 <tr>
                   <td class="px-4 py-3 text-slate-600">${monthName(item.mes)} ${item.anio}</td>
                   <td class="px-4 py-3 text-right font-semibold text-slate-800">${formatNumber(item.valor)}</td>
                   <td class="px-4 py-3 text-slate-500">${item.escenario ?? '—'}</td>
                   <td class="px-4 py-3 text-right text-slate-400 text-xs">${formatDate(item.fecha_captura ?? item.creado_en)}</td>
+                  <td class="px-4 py-3">
+                    <span class="inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold ${badgeClass}">
+                      ${statusLabel}
+                    </span>
+                    ${item.validado_por && item.fecha_validacion
+                      ? `<p class="mt-1 text-[11px] text-slate-400">Validado el ${formatDate(item.fecha_validacion)}</p>`
+                      : ''}
+                  </td>
+                  ${showValidation
+                    ? `
+                      <td class="px-4 py-3 text-right">
+                        ${canValidate
+                          ? `<button
+                              type="button"
+                              class="inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-emerald-700"
+                              data-action="validate"
+                              data-measurement-id="${item.id}"
+                            >
+                              <i class="fa-solid fa-shield-check"></i>
+                              Validar
+                            </button>`
+                          : '<span class="text-xs text-slate-400">—</span>'}
+                      </td>
+                    `
+                    : ''}
                 </tr>
               `;
             })
@@ -334,21 +391,53 @@ async function loadIndicatorContent(container, indicatorId) {
       getIndicatorTargets(indicatorId, { year: currentYear })
     ]);
 
-    // Calcular el siguiente mes a capturar
+    // Preparar catálogo de mediciones por mes del año seleccionado
+    const currentYearMeasurements = (history ?? []).filter(item => item.anio === currentYear);
+    const measurementsByMonth = new Map(
+      currentYearMeasurements.map(item => [Number(item.mes), item])
+    );
+
+    const capturedMonths = new Set(currentYearMeasurements.map(item => Number(item.mes)));
+    const availableMonths = months.filter(month => !capturedMonths.has(month.value));
+
+    // Calcular el siguiente mes sugerido
     let nextMonth = new Date().getMonth() + 1; // Mes actual por defecto
-    
+
     if (history && history.length > 0) {
-      // Encontrar el último mes capturado
-      const lastCapture = history[0]; // Ya está ordenado descendente
-      if (lastCapture.anio === currentYear) {
-        // Si hay capturas del año actual, sugerir el mes siguiente
-        nextMonth = (lastCapture.mes % 12) + 1;
-        // Si ya completó el año, volver a enero
-        if (lastCapture.mes === 12) {
+      const lastCapture = history[0];
+      if (lastCapture.anio === currentYear && lastCapture.mes) {
+        nextMonth = (Number(lastCapture.mes) % 12) + 1;
+        if (Number(lastCapture.mes) === 12) {
           nextMonth = 1;
         }
       }
     }
+
+    const disableCaptureForm = !esSubdirector && availableMonths.length === 0;
+    const suggestedMonth = esSubdirector
+      ? nextMonth
+      : availableMonths.length > 0
+        ? availableMonths[0].value
+        : nextMonth;
+
+    const initialMeasurement = esSubdirector ? measurementsByMonth.get(suggestedMonth) : null;
+    const initialValue = initialMeasurement ? initialMeasurement.valor ?? '' : '';
+    const initialButtonLabel = initialMeasurement ? 'Actualizar medición' : 'Guardar medición';
+
+    const monthOptions = months
+      .map((month) => {
+        const measurement = measurementsByMonth.get(month.value);
+        const isCaptured = Boolean(measurement);
+        const disabledAttr = !esSubdirector && isCaptured ? 'disabled' : '';
+        const selectedAttr = month.value === suggestedMonth ? 'selected' : '';
+        const statusLabel = isCaptured ? ` — ${formatNumber(measurement.valor)} (${formatValidationStatus(measurement.estatus_validacion)})` : '';
+        return `
+          <option value="${month.value}" ${selectedAttr} ${disabledAttr}>
+            ${month.label}${statusLabel}
+          </option>
+        `;
+      })
+      .join('');
 
     // Construcción dinámica: solo 1 columna si NO es subdirector, 2 columnas si SÍ es
     const gridClass = esSubdirector ? 'lg:grid-cols-2' : 'lg:grid-cols-1';
@@ -367,15 +456,20 @@ async function loadIndicatorContent(container, indicatorId) {
                 <p class="text-xs text-slate-500">${indicator.nombre}</p>
               </div>
             </div>
-            <form id="measurement-form" class="space-y-4">
+            <form
+              id="measurement-form"
+              class="space-y-4"
+              data-disable-capture="${disableCaptureForm ? 'true' : 'false'}"
+              data-editing-id="${initialMeasurement ? initialMeasurement.id : ''}"
+            >
               <label class="flex flex-col gap-1 text-sm text-slate-600">
                 Mes
-                <select name="month" class="rounded-lg border border-slate-200 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400">
-                  ${months.map((month) => `
-                    <option value="${month.value}" ${month.value === nextMonth ? 'selected' : ''}>
-                      ${month.label}
-                    </option>
-                  `).join('')}
+                <select
+                  name="month"
+                  class="rounded-lg border border-slate-200 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                  ${disableCaptureForm ? 'disabled' : ''}
+                >
+                  ${monthOptions}
                 </select>
               </label>
               <label class="flex flex-col gap-1 text-sm text-slate-600">
@@ -387,18 +481,31 @@ async function loadIndicatorContent(container, indicatorId) {
                   required
                   class="rounded-lg border border-slate-200 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
                   placeholder="Ingrese el valor"
+                  value="${initialValue}"
+                  ${disableCaptureForm && !esSubdirector ? 'disabled' : ''}
                 />
               </label>
-              <button type="submit" class="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700">
+              <button
+                type="submit"
+                class="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700"
+                ${disableCaptureForm && !esSubdirector ? 'disabled' : ''}
+              >
                 <i class="fa-solid fa-floppy-disk"></i>
-                Guardar medición
+                <span id="measurement-submit-label">${initialButtonLabel}</span>
               </button>
+              ${disableCaptureForm
+                ? `<p class="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-700">
+                    Todos los meses del ${currentYear} ya fueron capturados para este indicador. Contacte a su subdirección para realizar cambios.
+                  </p>`
+                : esSubdirector
+                  ? '<p class="text-[11px] text-slate-400">Seleccione un mes ya capturado para editarlo. Las actualizaciones quedarán registradas y deberán validarse nuevamente.</p>'
+                  : ''}
             </form>
           </div>
 
           <div class="space-y-3">
             <h3 class="text-sm font-semibold text-slate-600">Histórico de mediciones</h3>
-            <div id="history-table">${buildHistoryTable(history)}</div>
+            <div id="history-table">${buildHistoryTable(history, { showValidation: esSubdirector })}</div>
           </div>
         </div>
 
@@ -457,7 +564,7 @@ async function loadIndicatorContent(container, indicatorId) {
       </section>
     `;
 
-    initializeFormHandlers(indicatorId, esSubdirector);
+    initializeFormHandlers(indicatorId, esSubdirector, history, container);
   } catch (error) {
     console.error(error);
     container.innerHTML = '<div class="text-center py-8 text-red-500">Error al cargar el indicador</div>';
@@ -465,16 +572,72 @@ async function loadIndicatorContent(container, indicatorId) {
   }
 }
 
-function initializeFormHandlers(indicatorId, esSubdirector) {
+function initializeFormHandlers(indicatorId, esSubdirector, history, container) {
   const measurementForm = document.getElementById('measurement-form');
   const targetForm = document.getElementById('target-form');
   const historyTable = document.getElementById('history-table');
   const targetsTable = document.getElementById('targets-table');
+  const measurementSubmitLabel = document.getElementById('measurement-submit-label');
+
+  const measurementsByMonth = new Map(
+    (history ?? [])
+      .filter(item => item.anio === currentYear)
+      .map(item => [Number(item.mes), item])
+  );
 
   // Handler para formulario de mediciones
   if (measurementForm) {
+    const disableCapture = measurementForm.dataset.disableCapture === 'true';
+    const monthSelect = measurementForm.querySelector('select[name="month"]');
+    const valueInput = measurementForm.querySelector('input[name="value"]');
+    const submitButton = measurementForm.querySelector('button[type="submit"]');
+
+    if (disableCapture && !esSubdirector) {
+      measurementForm.querySelectorAll('input, select, button').forEach(element => {
+        element.disabled = true;
+      });
+    }
+
+    const syncFormWithMonth = () => {
+      if (!monthSelect || !valueInput || !submitButton) return;
+      const monthValue = Number(monthSelect.value);
+      const measurement = measurementsByMonth.get(monthValue);
+
+      if (esSubdirector && measurement) {
+        measurementForm.dataset.editingId = measurement.id ?? '';
+        valueInput.value = measurement.valor ?? '';
+        if (measurementSubmitLabel) {
+          measurementSubmitLabel.textContent = 'Actualizar medición';
+        }
+      } else {
+        measurementForm.dataset.editingId = '';
+        if (!disableCapture || esSubdirector) {
+          valueInput.value = '';
+        }
+        if (measurementSubmitLabel) {
+          measurementSubmitLabel.textContent = 'Guardar medición';
+        }
+      }
+    };
+
+    if (esSubdirector && monthSelect) {
+      monthSelect.addEventListener('change', syncFormWithMonth);
+      syncFormWithMonth();
+    } else if (monthSelect) {
+      monthSelect.addEventListener('change', () => {
+        measurementForm.dataset.editingId = '';
+        if (measurementSubmitLabel) {
+          measurementSubmitLabel.textContent = 'Guardar medición';
+        }
+      });
+    }
+
     measurementForm.addEventListener('submit', async (e) => {
       e.preventDefault();
+      if (disableCapture && !esSubdirector) {
+        showToast('Todos los meses del año seleccionado ya fueron capturados', { type: 'info' });
+        return;
+      }
       const submit = measurementForm.querySelector('button[type="submit"]');
       submit.disabled = true;
       submit.classList.add('opacity-70');
@@ -484,29 +647,41 @@ function initializeFormHandlers(indicatorId, esSubdirector) {
       const session = getSession();
       const userId = session?.user?.id;
 
-      const payload = {
-        indicador_id: indicatorId,
-        anio: currentYear,
-        mes: Number(formData.get('month')),
-        valor: Number(formData.get('value')),
-        capturado_por: userId
-        // escenario removido - la tabla mediciones no tiene esta columna
-      };
+      const editingId = measurementForm.dataset.editingId;
+      let shouldRestoreSubmit = true;
 
       try {
-        await saveMeasurement(payload);
-        showToast('Medición registrada correctamente');
-        measurementForm.reset();
-        
-        // Recargar histórico del año actual
-        const history = await getIndicatorHistory(indicatorId, { limit: 12, year: currentYear });
-        historyTable.innerHTML = buildHistoryTable(history);
+        if (editingId) {
+          await updateMeasurement(editingId, {
+            valor: Number(formData.get('value')),
+            editado_por: userId,
+            estatus_validacion: 'PENDIENTE'
+          });
+          showToast('Medición actualizada correctamente');
+        } else {
+          await saveMeasurement({
+            indicador_id: indicatorId,
+            anio: currentYear,
+            mes: Number(formData.get('month')),
+            valor: Number(formData.get('value')),
+            capturado_por: userId
+          });
+          showToast('Medición registrada correctamente');
+        }
+
+        shouldRestoreSubmit = false;
+        submit.disabled = false;
+        submit.classList.remove('opacity-70');
+        await loadIndicatorContent(container, indicatorId);
+        return;
       } catch (error) {
         console.error(error);
         showToast(error.message ?? 'No fue posible registrar la medición', { type: 'error' });
       } finally {
-        submit.disabled = false;
-        submit.classList.remove('opacity-70');
+        if (shouldRestoreSubmit) {
+          submit.disabled = false;
+          submit.classList.remove('opacity-70');
+        }
       }
     });
   }
@@ -543,6 +718,34 @@ function initializeFormHandlers(indicatorId, esSubdirector) {
       } finally {
         submit.disabled = false;
         submit.classList.remove('opacity-70');
+      }
+    });
+  }
+
+  if (historyTable && esSubdirector) {
+    historyTable.addEventListener('click', async (event) => {
+      const button = event.target.closest('button[data-action="validate"]');
+      if (!button) return;
+      const measurementId = button.dataset.measurementId;
+      if (!measurementId) return;
+
+      const originalContent = button.innerHTML;
+      button.disabled = true;
+      button.classList.add('opacity-70');
+      button.innerHTML = '<i class="fa-solid fa-spinner fa-spin"></i> Validando...';
+
+      try {
+        const session = getSession();
+        const userId = session?.user?.id ?? null;
+        await validateMeasurement(measurementId, { validado_por: userId });
+        showToast('Medición validada correctamente');
+        await loadIndicatorContent(container, indicatorId);
+      } catch (error) {
+        console.error(error);
+        showToast(error.message ?? 'No fue posible validar la medición', { type: 'error' });
+        button.disabled = false;
+        button.classList.remove('opacity-70');
+        button.innerHTML = originalContent;
       }
     });
   }

--- a/src/views/users.js
+++ b/src/views/users.js
@@ -1,4 +1,13 @@
-import { getAllUsers, updateUser, deactivateUser, assignUserToArea, removeUserFromArea, getAreas } from '../services/supabaseClient.js';
+import {
+  getAllUsers,
+  updateUser,
+  deactivateUser,
+  assignUserToArea,
+  removeUserFromArea,
+  updateUserAreaPermissions,
+  getAreas,
+  createUser
+} from '../services/supabaseClient.js';
 import { formatDate } from '../utils/formatters.js';
 import { showToast, renderLoading, renderError } from '../ui/feedback.js';
 
@@ -7,7 +16,6 @@ const ESTADOS = ['ACTIVO', 'INACTIVO'];
 
 let currentUsers = [];
 let currentAreas = [];
-let selectedUser = null;
 
 function escapeHtml(value) {
   if (value == null) return '';
@@ -114,6 +122,112 @@ function buildUsersTable(users, searchTerm = '') {
       `
     )
     .join('');
+}
+
+function buildCreateModal() {
+  return `
+    <div class="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/50 px-4" data-modal="create-user">
+      <div class="w-full max-w-lg rounded-2xl bg-white p-6 shadow-xl">
+        <div class="mb-4 flex items-center justify-between">
+          <div>
+            <h3 class="text-lg font-semibold text-slate-800">Registrar nuevo usuario</h3>
+            <p class="text-xs text-slate-500">
+              Asegúrese de que el usuario exista previamente en Supabase Authentication y pegue aquí su ID.
+            </p>
+          </div>
+          <button type="button" class="text-slate-400 hover:text-slate-600" data-modal-close>
+            <i class="fa-solid fa-xmark text-xl"></i>
+          </button>
+        </div>
+
+        <form id="create-user-form" class="space-y-4">
+          <div>
+            <label class="block text-sm font-medium text-slate-700 mb-1">ID del usuario (UUID)</label>
+            <input
+              type="text"
+              name="id"
+              required
+              placeholder="00000000-0000-0000-0000-000000000000"
+              class="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-100"
+            />
+            <p class="mt-1 text-xs text-slate-400">
+              Lo puede copiar desde la sección de Authentication del panel de Supabase.
+            </p>
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-slate-700 mb-1">Nombre completo</label>
+            <input
+              type="text"
+              name="nombre_completo"
+              required
+              class="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-100"
+            />
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-slate-700 mb-1">Correo electrónico</label>
+            <input
+              type="email"
+              name="email"
+              required
+              class="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-100"
+            />
+          </div>
+
+          <div class="grid grid-cols-2 gap-4">
+            <div>
+              <label class="block text-sm font-medium text-slate-700 mb-1">Puesto</label>
+              <input
+                type="text"
+                name="puesto"
+                class="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-100"
+              />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-slate-700 mb-1">Teléfono</label>
+              <input
+                type="tel"
+                name="telefono"
+                class="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-100"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-slate-700 mb-1">Rol principal</label>
+            <select
+              name="rol_principal"
+              required
+              class="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-100"
+            >
+              <option value="">Seleccionar rol</option>
+              ${ROLES.map(rol => `
+                <option value="${rol}">${rol}</option>
+              `).join('')}
+            </select>
+          </div>
+
+          <div class="flex gap-3 pt-2">
+            <button
+              type="submit"
+              class="flex-1 rounded-lg bg-primary-600 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-700"
+            >
+              <i class="fa-solid fa-user-plus mr-2"></i>
+              Registrar usuario
+            </button>
+            <button
+              type="button"
+              data-modal-close
+              class="rounded-lg border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 hover:bg-slate-50"
+            >
+              Cancelar
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  `;
 }
 
 function buildEditModal(user) {
@@ -243,26 +357,41 @@ function buildAreasModal(user) {
           <h4 class="text-sm font-semibold text-slate-700 mb-2">Áreas asignadas</h4>
           <div class="space-y-2" id="assigned-areas">
             ${user.areas.length ? user.areas.map(ua => `
-              <div class="flex items-center justify-between rounded-lg border border-slate-200 bg-slate-50 p-3">
+              <div class="flex flex-col gap-3 rounded-lg border border-slate-200 bg-slate-50 p-3 sm:flex-row sm:items-center sm:justify-between">
                 <div class="flex-1">
                   <p class="font-medium text-slate-800">${escapeHtml(ua.areas?.nombre || 'Área desconocida')}</p>
-                  <p class="text-xs text-slate-500">Rol: ${escapeHtml(ua.rol)}</p>
-                  <div class="mt-1 flex gap-2 text-xs">
-                    ${ua.puede_capturar ? '<span class="text-blue-600">✓ Captura</span>' : '<span class="text-slate-400">✗ Captura</span>'}
-                    ${ua.puede_editar ? '<span class="text-amber-600">✓ Edición</span>' : '<span class="text-slate-400">✗ Edición</span>'}
-                    ${ua.puede_eliminar ? '<span class="text-red-600">✓ Eliminación</span>' : '<span class="text-slate-400">✗ Eliminación</span>'}
+                  <p class="text-xs text-slate-500">Rol: ${escapeHtml(ua.rol || 'Sin rol')}</p>
+                  <div class="mt-1 flex flex-wrap gap-2 text-xs">
+                    ${ua.puede_capturar ? '<span class="rounded bg-blue-100 px-2 py-0.5 text-blue-700">✓ Captura</span>' : '<span class="text-slate-400">✗ Captura</span>'}
+                    ${ua.puede_editar ? '<span class="rounded bg-amber-100 px-2 py-0.5 text-amber-700">✓ Edición</span>' : '<span class="text-slate-400">✗ Edición</span>'}
+                    ${ua.puede_eliminar ? '<span class="rounded bg-red-100 px-2 py-0.5 text-red-700">✓ Eliminación</span>' : '<span class="text-slate-400">✗ Eliminación</span>'}
                   </div>
                 </div>
-                <button
-                  type="button"
-                  class="ml-4 text-red-600 hover:text-red-700"
-                  data-action="remove-area"
-                  data-usuario-id="${user.id}"
-                  data-area-id="${ua.area_id}"
-                  title="Remover área"
-                >
-                  <i class="fa-solid fa-trash"></i>
-                </button>
+                <div class="flex items-center gap-2 sm:ml-4">
+                  <button
+                    type="button"
+                    class="rounded-lg border border-primary-100 px-3 py-1.5 text-sm font-medium text-primary-600 hover:bg-primary-50"
+                    data-action="edit-area"
+                    data-usuario-id="${user.id}"
+                    data-assignment-id="${ua.id}"
+                    title="Editar asignación"
+                  >
+                    <i class="fa-solid fa-pen-to-square mr-1"></i>
+                    Editar
+                  </button>
+                  <button
+                    type="button"
+                    class="rounded-lg border border-red-100 px-3 py-1.5 text-sm font-medium text-red-600 hover:bg-red-50"
+                    data-action="remove-area"
+                    data-usuario-id="${user.id}"
+                    data-area-id="${ua.area_id}"
+                    data-assignment-id="${ua.id}"
+                    title="Remover área"
+                  >
+                    <i class="fa-solid fa-trash mr-1"></i>
+                    Quitar
+                  </button>
+                </div>
               </div>
             `).join('') : '<p class="text-sm text-slate-400 py-4 text-center">No tiene áreas asignadas</p>'}
           </div>
@@ -323,6 +452,90 @@ function buildAreasModal(user) {
             </button>
           </form>
         </div>
+      </div>
+    </div>
+  `;
+}
+
+function buildEditAreaModal(user, assignment) {
+  return `
+    <div class="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/50 px-4" data-modal="edit-area">
+      <div class="w-full max-w-xl rounded-2xl bg-white p-6 shadow-xl">
+        <div class="mb-4 flex items-center justify-between">
+          <div>
+            <h3 class="text-lg font-semibold text-slate-800">Editar área asignada</h3>
+            <p class="text-sm text-slate-500">${escapeHtml(user.nombre_completo)}</p>
+          </div>
+          <button type="button" class="text-slate-400 hover:text-slate-600" data-modal-close>
+            <i class="fa-solid fa-xmark text-xl"></i>
+          </button>
+        </div>
+
+        <form id="edit-area-form" class="space-y-4">
+          <input type="hidden" name="usuario_area_id" value="${assignment.id}" />
+          <input type="hidden" name="usuario_id" value="${user.id}" />
+
+          <div>
+            <label class="block text-xs font-medium text-slate-700 mb-1">Área asignada</label>
+            <select
+              name="area_id"
+              required
+              class="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-100"
+            >
+              <option value="">Seleccionar área</option>
+              ${currentAreas.map(area => `
+                <option value="${area.id}" ${String(area.id) === String(assignment.area_id) ? 'selected' : ''}>
+                  ${escapeHtml(area.nombre)}
+                </option>
+              `).join('')}
+            </select>
+          </div>
+
+          <div>
+            <label class="block text-xs font-medium text-slate-700 mb-1">Rol en área</label>
+            <select
+              name="rol"
+              required
+              class="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-100"
+            >
+              ${ROLES.map(rol => `
+                <option value="${rol}" ${assignment.rol === rol ? 'selected' : ''}>${rol}</option>
+              `).join('')}
+            </select>
+          </div>
+
+          <div class="flex flex-wrap gap-4">
+            <label class="flex items-center gap-2 text-sm text-slate-700">
+              <input type="checkbox" name="puede_capturar" ${assignment.puede_capturar ? 'checked' : ''} class="rounded border-slate-300 text-primary-600" />
+              Puede capturar
+            </label>
+            <label class="flex items-center gap-2 text-sm text-slate-700">
+              <input type="checkbox" name="puede_editar" ${assignment.puede_editar ? 'checked' : ''} class="rounded border-slate-300 text-primary-600" />
+              Puede editar
+            </label>
+            <label class="flex items-center gap-2 text-sm text-slate-700">
+              <input type="checkbox" name="puede_eliminar" ${assignment.puede_eliminar ? 'checked' : ''} class="rounded border-slate-300 text-primary-600" />
+              Puede eliminar
+            </label>
+          </div>
+
+          <div class="flex gap-3 pt-2">
+            <button
+              type="submit"
+              class="flex-1 rounded-lg bg-primary-600 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-700"
+            >
+              <i class="fa-solid fa-floppy-disk mr-2"></i>
+              Guardar cambios
+            </button>
+            <button
+              type="button"
+              data-modal-close
+              class="rounded-lg border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 hover:bg-slate-50"
+            >
+              Cancelar
+            </button>
+          </div>
+        </form>
       </div>
     </div>
   `;
@@ -416,9 +629,8 @@ function initializeEventListeners() {
   // Botón nuevo usuario
   if (newUserButton) {
     newUserButton.addEventListener('click', () => {
-      showToast('Para crear un nuevo usuario, primero debe crearse en Supabase Authentication', { 
-        type: 'warning' 
-      });
+      modalContainer.innerHTML = buildCreateModal();
+      bindModalActions();
     });
   }
 
@@ -475,14 +687,51 @@ function initializeEventListeners() {
 
   function bindModalActions() {
     // Cerrar modal
-    document.querySelectorAll('[data-modal-close]').forEach(btn => {
+    modalContainer.querySelectorAll('[data-modal-close]').forEach(btn => {
       btn.addEventListener('click', () => {
         modalContainer.innerHTML = '';
       });
     });
 
+    const createForm = modalContainer.querySelector('#create-user-form');
+    if (createForm) {
+      createForm.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const formData = new FormData(e.target);
+        const payload = {
+          id: formData.get('id')?.trim(),
+          nombre_completo: formData.get('nombre_completo')?.trim(),
+          email: formData.get('email')?.trim(),
+          puesto: formData.get('puesto')?.trim() || null,
+          telefono: formData.get('telefono')?.trim() || null,
+          rol_principal: formData.get('rol_principal')
+        };
+
+        if (!payload.id) {
+          showToast('Debe capturar el ID que genera Supabase Authentication para el usuario', { type: 'warning' });
+          return;
+        }
+
+        try {
+          await createUser(payload);
+          showToast('Usuario creado correctamente');
+          modalContainer.innerHTML = '';
+          currentUsers = await getAllUsers();
+          tableBody.innerHTML = buildUsersTable(currentUsers);
+          bindTableActions();
+        } catch (error) {
+          console.error(error);
+          let message = 'No fue posible crear el usuario';
+          if (error?.code === '23505' || /duplicate/i.test(error?.message ?? '')) {
+            message = 'Ya existe un usuario registrado con ese ID o correo electrónico';
+          }
+          showToast(message, { type: 'error' });
+        }
+      });
+    }
+
     // Form editar usuario
-    const editForm = document.getElementById('edit-user-form');
+    const editForm = modalContainer.querySelector('#edit-user-form');
     if (editForm) {
       editForm.addEventListener('submit', async (e) => {
         e.preventDefault();
@@ -512,7 +761,7 @@ function initializeEventListeners() {
     }
 
     // Form asignar área
-    const assignForm = document.getElementById('assign-area-form');
+    const assignForm = modalContainer.querySelector('#assign-area-form');
     if (assignForm) {
       assignForm.addEventListener('submit', async (e) => {
         e.preventDefault();
@@ -529,19 +778,79 @@ function initializeEventListeners() {
         try {
           await assignUserToArea(payload);
           showToast('Área asignada correctamente');
-          modalContainer.innerHTML = '';
           currentUsers = await getAllUsers();
           tableBody.innerHTML = buildUsersTable(currentUsers);
           bindTableActions();
+
+          const updatedUser = currentUsers.find(u => String(u.id) === String(payload.usuario_id));
+          if (updatedUser) {
+            modalContainer.innerHTML = buildAreasModal(updatedUser);
+            bindModalActions();
+          } else {
+            modalContainer.innerHTML = '';
+          }
         } catch (error) {
           console.error(error);
           showToast('No fue posible asignar el área', { type: 'error' });
         }
       });
     }
-  }
-// Remover área (AGREGAR ESTE CÓDIGO)
-    document.querySelectorAll('[data-action="remove-area"]').forEach(btn => {
+
+    const editAreaForm = modalContainer.querySelector('#edit-area-form');
+    if (editAreaForm) {
+      editAreaForm.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const formData = new FormData(e.target);
+        const usuarioAreaId = formData.get('usuario_area_id');
+        const usuarioId = formData.get('usuario_id');
+        const updates = {
+          area_id: formData.get('area_id'),
+          rol: formData.get('rol'),
+          puede_capturar: formData.get('puede_capturar') === 'on',
+          puede_editar: formData.get('puede_editar') === 'on',
+          puede_eliminar: formData.get('puede_eliminar') === 'on',
+          estado: 'ACTIVO'
+        };
+
+        try {
+          await updateUserAreaPermissions(usuarioAreaId, updates);
+          showToast('Área actualizada correctamente');
+          currentUsers = await getAllUsers();
+          tableBody.innerHTML = buildUsersTable(currentUsers);
+          bindTableActions();
+
+          const updatedUser = currentUsers.find(u => String(u.id) === String(usuarioId));
+          if (updatedUser) {
+            modalContainer.innerHTML = buildAreasModal(updatedUser);
+            bindModalActions();
+          } else {
+            modalContainer.innerHTML = '';
+          }
+        } catch (error) {
+          console.error(error);
+          showToast('No fue posible actualizar el área', { type: 'error' });
+        }
+      });
+    }
+
+    modalContainer.querySelectorAll('[data-action="edit-area"]').forEach(btn => {
+      btn.addEventListener('click', (e) => {
+        const usuarioId = e.currentTarget.dataset.usuarioId;
+        const assignmentId = e.currentTarget.dataset.assignmentId;
+        const user = currentUsers.find(u => String(u.id) === String(usuarioId));
+        if (!user) return;
+
+        const assignment = user.areas?.find(ua => String(ua.id) === String(assignmentId))
+          || user.areas?.find(ua => String(ua.area_id) === String(assignmentId));
+
+        if (!assignment) return;
+
+        modalContainer.innerHTML = buildEditAreaModal(user, assignment);
+        bindModalActions();
+      });
+    });
+
+    modalContainer.querySelectorAll('[data-action="remove-area"]').forEach(btn => {
       btn.addEventListener('click', async (e) => {
         const usuarioId = e.currentTarget.dataset.usuarioId;
         const areaId = e.currentTarget.dataset.areaId;
@@ -550,10 +859,17 @@ function initializeEventListeners() {
           try {
             await removeUserFromArea(usuarioId, areaId);
             showToast('Área removida correctamente');
-            modalContainer.innerHTML = '';
             currentUsers = await getAllUsers();
             tableBody.innerHTML = buildUsersTable(currentUsers);
             bindTableActions();
+
+            const updatedUser = currentUsers.find(u => String(u.id) === String(usuarioId));
+            if (updatedUser) {
+              modalContainer.innerHTML = buildAreasModal(updatedUser);
+              bindModalActions();
+            } else {
+              modalContainer.innerHTML = '';
+            }
           } catch (error) {
             console.error(error);
             showToast('No fue posible remover el área', { type: 'error' });
@@ -561,4 +877,5 @@ function initializeEventListeners() {
         }
       });
     });
-  } // ← Este es el cierre de bindModalActions
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated modal so admins can register users after creating them in Supabase Authentication
- handle the create-user form in the admin page and refresh the listing once a user profile is saved
- update the Supabase client helper to accept an explicit ID when inserting new profiles

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0118537b0832e83c86f1ee3341709