### PR TITLE
Add default password flow and account security controls

### DIFF
--- a/src/layouts/AppLayout.jsx
+++ b/src/layouts/AppLayout.jsx
@@ -1,7 +1,22 @@
 import { Outlet, NavLink, useLocation, useNavigate } from 'react-router-dom';
-import { useEffect, useMemo, useState } from 'react';
-import { BarChart3, ListChecks, ClipboardPen, LogOut, Users, Presentation, Menu } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  BarChart3,
+  ListChecks,
+  ClipboardPen,
+  Users,
+  Presentation,
+  Menu,
+  ChevronDown,
+  KeyRound,
+  Eye,
+  EyeOff,
+  LogOut,
+  X
+} from 'lucide-react';
 import { useAuth } from '../context/AuthContext.jsx';
+import { supabase } from '../lib/supabaseClient.js';
+import { showToast } from '../ui/feedback.js';
 
 const navigation = [
   { name: 'Panel directivos', to: '/panel-directivos', icon: BarChart3 },
@@ -16,16 +31,36 @@ function classNames(...classes) {
 }
 
 export default function AppLayout() {
-  const { profile, signOut } = useAuth();
+  const { profile, signOut, session } = useAuth();
   const location = useLocation();
   const navigate = useNavigate();
   const [mobileOpen, setMobileOpen] = useState(false);
   const [isSigningOut, setIsSigningOut] = useState(false);
+  const [isAccountMenuOpen, setIsAccountMenuOpen] = useState(false);
+  const [isChangePasswordOpen, setIsChangePasswordOpen] = useState(false);
+  const [isUpdatingPassword, setIsUpdatingPassword] = useState(false);
+  const [passwordForm, setPasswordForm] = useState({
+    currentPassword: '',
+    newPassword: '',
+    confirmPassword: ''
+  });
+  const [passwordErrors, setPasswordErrors] = useState({});
+  const [passwordVisibility, setPasswordVisibility] = useState({
+    currentPassword: false,
+    newPassword: false,
+    confirmPassword: false
+  });
   const logoUrl = useMemo(() => new URL('../../assets/AIFA_logo.png', import.meta.url).href, []);
+  const accountMenuRef = useRef(null);
 
   const normalizedRole = useMemo(
     () => (profile?.rol ?? profile?.puesto)?.toString().toLowerCase() ?? null,
     [profile]
+  );
+
+  const accountEmail = useMemo(
+    () => (profile?.email ?? profile?.usuario?.email ?? session?.user?.email ?? '').toLowerCase(),
+    [profile?.email, profile?.usuario?.email, session?.user?.email]
   );
 
   const allowedPaths = useMemo(() => {
@@ -52,6 +87,7 @@ export default function AppLayout() {
 
   useEffect(() => {
     setMobileOpen(false);
+    setIsAccountMenuOpen(false);
   }, [location.pathname]);
 
   const fallbackPath = useMemo(() => {
@@ -89,6 +125,9 @@ export default function AppLayout() {
 
   const handleSignOut = async () => {
     if (isSigningOut) return;
+    setIsAccountMenuOpen(false);
+    setMobileOpen(false);
+    setIsChangePasswordOpen(false);
     setIsSigningOut(true);
     try {
       await signOut();
@@ -97,6 +136,171 @@ export default function AppLayout() {
       console.error('No fue posible cerrar la sesión', error);
     } finally {
       setIsSigningOut(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!isAccountMenuOpen) return;
+
+    const handleClickOutside = event => {
+      if (accountMenuRef.current && !accountMenuRef.current.contains(event.target)) {
+        setIsAccountMenuOpen(false);
+      }
+    };
+
+    const handleEscape = event => {
+      if (event.key === 'Escape') {
+        setIsAccountMenuOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [isAccountMenuOpen]);
+
+  useEffect(() => {
+    if (!isChangePasswordOpen) return;
+
+    const handleEscape = event => {
+      if (event.key === 'Escape') {
+        setIsChangePasswordOpen(false);
+      }
+    };
+
+    document.addEventListener('keydown', handleEscape);
+
+    return () => {
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [isChangePasswordOpen]);
+
+  useEffect(() => {
+    document.body.style.overflow = isChangePasswordOpen ? 'hidden' : '';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isChangePasswordOpen]);
+
+  const resetPasswordForm = () => {
+    setPasswordForm({ currentPassword: '', newPassword: '', confirmPassword: '' });
+    setPasswordErrors({});
+    setPasswordVisibility({ currentPassword: false, newPassword: false, confirmPassword: false });
+  };
+
+  const handleOpenChangePassword = () => {
+    resetPasswordForm();
+    setIsAccountMenuOpen(false);
+    setIsChangePasswordOpen(true);
+  };
+
+  const handleCloseChangePassword = () => {
+    setIsChangePasswordOpen(false);
+    resetPasswordForm();
+  };
+
+  const togglePasswordVisibility = field => {
+    setPasswordVisibility(prev => ({ ...prev, [field]: !prev[field] }));
+  };
+
+  const handlePasswordInputChange = (field, value) => {
+    setPasswordForm(prev => ({ ...prev, [field]: value }));
+    setPasswordErrors(prev => ({ ...prev, [field]: undefined }));
+  };
+
+  const validatePasswordForm = () => {
+    const errors = {};
+    const { currentPassword, newPassword, confirmPassword } = passwordForm;
+
+    if (!currentPassword) {
+      errors.currentPassword = 'Capture la contraseña anterior.';
+    }
+
+    if (!newPassword) {
+      errors.newPassword = ['Capture la nueva contraseña.'];
+    } else {
+      const newPasswordErrors = [];
+
+      if (newPassword === currentPassword) {
+        newPasswordErrors.push('La nueva contraseña debe ser diferente a la anterior.');
+      }
+
+      const requirementErrors = [
+        { test: newPassword.length >= 8, message: 'Debe tener al menos 8 caracteres.' },
+        { test: /[A-Z]/.test(newPassword), message: 'Debe incluir al menos una letra mayúscula.' },
+        { test: /[a-z]/.test(newPassword), message: 'Debe incluir al menos una letra minúscula.' },
+        { test: /[0-9]/.test(newPassword), message: 'Debe incluir al menos un número.' },
+        { test: /[^A-Za-z0-9]/.test(newPassword), message: 'Debe incluir al menos un carácter especial.' }
+      ]
+        .filter(requirement => !requirement.test)
+        .map(requirement => requirement.message);
+
+      if (requirementErrors.length) {
+        newPasswordErrors.push(...requirementErrors);
+      }
+
+      if (newPasswordErrors.length) {
+        errors.newPassword = newPasswordErrors;
+      }
+    }
+
+    if (!confirmPassword) {
+      errors.confirmPassword = 'Confirme la nueva contraseña.';
+    } else if (newPassword !== confirmPassword) {
+      errors.confirmPassword = 'Las contraseñas no coinciden.';
+    }
+
+    return errors;
+  };
+
+  const handlePasswordSubmit = async event => {
+    event.preventDefault();
+    const errors = validatePasswordForm();
+    if (Object.keys(errors).length) {
+      setPasswordErrors(errors);
+      return;
+    }
+
+    if (!accountEmail) {
+      showToast('No se pudo identificar el correo de la cuenta.', { type: 'error' });
+      return;
+    }
+
+    setIsUpdatingPassword(true);
+
+    try {
+      const { currentPassword, newPassword } = passwordForm;
+      const { error: verificationError } = await supabase.auth.signInWithPassword({
+        email: accountEmail,
+        password: currentPassword
+      });
+
+      if (verificationError) {
+        setPasswordErrors(prev => ({ ...prev, currentPassword: 'La contraseña anterior no es correcta.' }));
+        showToast('La contraseña anterior no es correcta.', { type: 'error' });
+        return;
+      }
+
+      const { error: updateError } = await supabase.auth.updateUser({ password: newPassword });
+
+      if (updateError) {
+        throw updateError;
+      }
+
+      showToast('Contraseña actualizada correctamente.');
+      setIsChangePasswordOpen(false);
+      resetPasswordForm();
+    } catch (error) {
+      console.error('No fue posible actualizar la contraseña', error);
+      if (!/contraseña anterior no es correcta/i.test(error?.message ?? '')) {
+        showToast('No fue posible actualizar la contraseña. Intente nuevamente.', { type: 'error' });
+      }
+    } finally {
+      setIsUpdatingPassword(false);
     }
   };
 
@@ -145,14 +349,53 @@ export default function AppLayout() {
                   <p className="font-semibold text-slate-800">{profile.nombre_completo ?? profile.nombre}</p>
                   <p className="text-[11px] uppercase tracking-widest text-slate-400">{profile.puesto ?? profile.rol}</p>
                 </div>
-                <button
-                  onClick={handleSignOut}
-                  disabled={isSigningOut}
-                  className="inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-1.5 text-sm font-medium text-slate-600 transition hover:border-aifa-green hover:text-aifa-green disabled:cursor-not-allowed disabled:opacity-70"
-                >
-                  <LogOut className="h-4 w-4" />
-                  <span className="hidden sm:inline">Cerrar sesión</span>
-                </button>
+                <div className="relative" ref={accountMenuRef}>
+                  <button
+                    type="button"
+                    onClick={() => setIsAccountMenuOpen(open => !open)}
+                    className="inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-1.5 text-sm font-medium text-slate-600 transition hover:border-aifa-green hover:text-aifa-green"
+                    aria-haspopup="menu"
+                    aria-expanded={isAccountMenuOpen}
+                  >
+                    <span className="max-w-[10rem] truncate text-left sm:max-w-none">
+                      {accountEmail || 'Cuenta'}
+                    </span>
+                    <ChevronDown
+                      className={`h-4 w-4 transition-transform ${isAccountMenuOpen ? 'rotate-180 text-aifa-green' : ''}`}
+                    />
+                  </button>
+
+                  {isAccountMenuOpen && (
+                    <div className="absolute right-0 z-30 mt-2 w-64 overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-xl">
+                      <div className="border-b border-slate-100 px-4 py-3 text-sm">
+                        <p className="font-semibold text-slate-800">{profile.nombre_completo ?? profile.nombre}</p>
+                        <p className="mt-1 break-all text-xs uppercase tracking-widest text-slate-400">
+                          {profile.puesto ?? profile.rol}
+                        </p>
+                        <p className="mt-1 break-all text-xs text-slate-500">{accountEmail}</p>
+                      </div>
+                      <div className="flex flex-col py-1 text-sm text-slate-600">
+                        <button
+                          type="button"
+                          className="flex items-center gap-2 px-4 py-2 text-left transition hover:bg-emerald-50 hover:text-aifa-green"
+                          onClick={handleOpenChangePassword}
+                        >
+                          <KeyRound className="h-4 w-4" />
+                          Cambiar contraseña
+                        </button>
+                        <button
+                          type="button"
+                          className="flex items-center gap-2 px-4 py-2 text-left transition hover:bg-rose-50 hover:text-rose-600 disabled:cursor-not-allowed disabled:opacity-70"
+                          onClick={handleSignOut}
+                          disabled={isSigningOut}
+                        >
+                          <LogOut className="h-4 w-4" />
+                          Cerrar sesión
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </div>
               </div>
             ) : (
               <p className="text-sm text-slate-500">Sesión no disponible</p>
@@ -194,6 +437,38 @@ export default function AppLayout() {
                 );
               })}
             </nav>
+            {profile && (
+              <div className="mt-4 rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-600">
+                <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">Cuenta</p>
+                <p className="mt-1 font-semibold text-slate-800">{profile.nombre_completo ?? profile.nombre}</p>
+                <p className="mt-1 break-all text-xs text-slate-500">{accountEmail}</p>
+                <div className="mt-3 flex flex-col gap-2">
+                  <button
+                    type="button"
+                    className="flex items-center gap-2 rounded-lg border border-emerald-200 px-3 py-2 text-sm font-medium text-emerald-700 transition hover:bg-emerald-50"
+                    onClick={() => {
+                      setMobileOpen(false);
+                      handleOpenChangePassword();
+                    }}
+                  >
+                    <KeyRound className="h-4 w-4" />
+                    Cambiar contraseña
+                  </button>
+                  <button
+                    type="button"
+                    className="flex items-center gap-2 rounded-lg border border-rose-200 px-3 py-2 text-sm font-medium text-rose-600 transition hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-70"
+                    onClick={() => {
+                      setMobileOpen(false);
+                      handleSignOut();
+                    }}
+                    disabled={isSigningOut}
+                  >
+                    <LogOut className="h-4 w-4" />
+                    Cerrar sesión
+                  </button>
+                </div>
+              </div>
+            )}
           </div>
         )}
       </header>
@@ -206,6 +481,134 @@ export default function AppLayout() {
           <Outlet />
         </div>
       </main>
+
+      {isChangePasswordOpen && (
+        <div className="fixed inset-0 z-40 flex items-center justify-center bg-slate-900/60 px-4">
+          <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-2xl">
+            <div className="mb-4 flex items-center justify-between">
+              <div>
+                <h2 className="text-lg font-semibold text-slate-800">Cambiar contraseña</h2>
+                <p className="text-xs text-slate-500">
+                  La contraseña debe incluir al menos 8 caracteres, combinando mayúsculas, minúsculas, números y símbolos.
+                </p>
+              </div>
+              <button
+                type="button"
+                className="rounded-full p-1 text-slate-400 transition hover:bg-slate-100 hover:text-slate-600"
+                onClick={handleCloseChangePassword}
+                aria-label="Cerrar"
+              >
+                <span className="sr-only">Cerrar modal</span>
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+            <form className="space-y-4" onSubmit={handlePasswordSubmit}>
+              <div>
+                <label className="text-sm font-medium text-slate-700">Contraseña anterior</label>
+                <div className="relative mt-1">
+                  <input
+                    type={passwordVisibility.currentPassword ? 'text' : 'password'}
+                    className={`w-full rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-100 ${
+                      passwordErrors.currentPassword ? 'border-rose-400' : 'border-slate-200'
+                    }`}
+                    value={passwordForm.currentPassword}
+                    onChange={event => handlePasswordInputChange('currentPassword', event.target.value)}
+                    autoComplete="current-password"
+                  />
+                  <button
+                    type="button"
+                    className="absolute inset-y-0 right-3 flex items-center text-slate-400 transition hover:text-slate-600"
+                    onClick={() => togglePasswordVisibility('currentPassword')}
+                    aria-label={passwordVisibility.currentPassword ? 'Ocultar contraseña' : 'Mostrar contraseña'}
+                  >
+                    {passwordVisibility.currentPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                  </button>
+                </div>
+                {passwordErrors.currentPassword && (
+                  <p className="mt-1 text-xs text-rose-600">{passwordErrors.currentPassword}</p>
+                )}
+              </div>
+
+              <div>
+                <label className="text-sm font-medium text-slate-700">Nueva contraseña</label>
+                <div className="relative mt-1">
+                  <input
+                    type={passwordVisibility.newPassword ? 'text' : 'password'}
+                    className={`w-full rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-100 ${
+                      passwordErrors.newPassword ? 'border-rose-400' : 'border-slate-200'
+                    }`}
+                    value={passwordForm.newPassword}
+                    onChange={event => handlePasswordInputChange('newPassword', event.target.value)}
+                    autoComplete="new-password"
+                  />
+                  <button
+                    type="button"
+                    className="absolute inset-y-0 right-3 flex items-center text-slate-400 transition hover:text-slate-600"
+                    onClick={() => togglePasswordVisibility('newPassword')}
+                    aria-label={passwordVisibility.newPassword ? 'Ocultar contraseña' : 'Mostrar contraseña'}
+                  >
+                    {passwordVisibility.newPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                  </button>
+                </div>
+                {Array.isArray(passwordErrors.newPassword) && passwordErrors.newPassword.length > 0 && (
+                  <ul className="mt-2 space-y-1 text-xs text-rose-600">
+                    {passwordErrors.newPassword.map((message, index) => (
+                      <li key={index} className="flex items-start gap-1">
+                        <span className="mt-0.5 block h-1 w-1 rounded-full bg-rose-500" />
+                        <span>{message}</span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+
+              <div>
+                <label className="text-sm font-medium text-slate-700">Confirmar nueva contraseña</label>
+                <div className="relative mt-1">
+                  <input
+                    type={passwordVisibility.confirmPassword ? 'text' : 'password'}
+                    className={`w-full rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-100 ${
+                      passwordErrors.confirmPassword ? 'border-rose-400' : 'border-slate-200'
+                    }`}
+                    value={passwordForm.confirmPassword}
+                    onChange={event => handlePasswordInputChange('confirmPassword', event.target.value)}
+                    autoComplete="new-password"
+                  />
+                  <button
+                    type="button"
+                    className="absolute inset-y-0 right-3 flex items-center text-slate-400 transition hover:text-slate-600"
+                    onClick={() => togglePasswordVisibility('confirmPassword')}
+                    aria-label={passwordVisibility.confirmPassword ? 'Ocultar contraseña' : 'Mostrar contraseña'}
+                  >
+                    {passwordVisibility.confirmPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                  </button>
+                </div>
+                {passwordErrors.confirmPassword && (
+                  <p className="mt-1 text-xs text-rose-600">{passwordErrors.confirmPassword}</p>
+                )}
+              </div>
+
+              <div className="flex gap-3 pt-2">
+                <button
+                  type="submit"
+                  className="flex-1 rounded-lg bg-aifa-green px-4 py-2 text-sm font-semibold text-white transition hover:bg-emerald-600 disabled:cursor-not-allowed disabled:opacity-70"
+                  disabled={isUpdatingPassword}
+                >
+                  {isUpdatingPassword ? 'Guardando...' : 'Guardar nueva contraseña'}
+                </button>
+                <button
+                  type="button"
+                  className="rounded-lg border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-50"
+                  onClick={handleCloseChangePassword}
+                  disabled={isUpdatingPassword}
+                >
+                  Cancelar
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/services/supabaseClient.js
+++ b/src/services/supabaseClient.js
@@ -1140,7 +1140,9 @@ export async function getAllUsers() {
   const { data: usuariosAreas, error: areasError } = await supabase
     .from('usuario_areas')
     .select(`
+      id,
       usuario_id,
+      area_id,
       rol,
       puede_capturar,
       puede_editar,
@@ -1175,25 +1177,133 @@ export async function getAllUsers() {
 /**
  * Crear nuevo usuario
  */
-export async function createUser({ email, password, nombre_completo, puesto, rol_principal, telefono }) {
-  // 1. Crear usuario en Supabase Auth (requiere permisos de admin)
-  // NOTA: Esto normalmente se hace desde una función del servidor (Edge Function)
-  // Por ahora solo creamos el perfil, el admin debe crear el usuario Auth manualmente
-  
-  const { data, error } = await supabase
-    .from('perfiles')
-    .insert({
-      email,
-      nombre_completo,
-      puesto,
-      rol_principal,
-      telefono,
-      estado: 'ACTIVO'
-    })
-    .select()
-    .single();
+function buildDefaultPassword(email) {
+  if (!email) {
+    throw new Error('El correo electrónico es obligatorio');
+  }
 
-  if (error) throw error;
+  const normalizedEmail = email.trim().toLowerCase();
+  const [localPart = 'usuario'] = normalizedEmail.split('@');
+  const safeLocalPart = localPart.length ? localPart : 'usuario';
+  return `${safeLocalPart}1544`;
+}
+
+export async function createUser({ email, nombre_completo, puesto, rol_principal, telefono }) {
+  if (!email) {
+    throw new Error('El correo electrónico es obligatorio');
+  }
+
+  const normalizedEmail = email.trim().toLowerCase();
+  const fullName = nombre_completo?.trim() || null;
+
+  const {
+    data: sessionData
+  } = await supabase.auth.getSession();
+  const adminSession = sessionData?.session ?? null;
+
+  const temporaryPassword = buildDefaultPassword(normalizedEmail);
+  const { data: signUpData, error: signUpError } = await supabase.auth.signUp({
+    email: normalizedEmail,
+    password: temporaryPassword,
+    options: fullName
+      ? {
+          data: {
+            full_name: fullName
+          }
+        }
+      : undefined
+  });
+
+  const authUserId = signUpData?.user?.id ?? null;
+  const alreadyRegistered = Boolean(
+    signUpError && /already registered|user already exists/i.test(signUpError.message ?? '')
+  );
+
+  if (!authUserId && !alreadyRegistered) {
+    throw signUpError ?? new Error('No fue posible crear el usuario en Supabase Auth');
+  }
+
+  if (signUpError && !alreadyRegistered) {
+    throw signUpError;
+  }
+
+  if (adminSession?.access_token && adminSession?.refresh_token) {
+    await supabase.auth
+      .setSession({
+        access_token: adminSession.access_token,
+        refresh_token: adminSession.refresh_token
+      })
+      .catch(async () => {
+        // Si la restauración falla intentamos cerrar sesión para no dejar la cuenta recién creada activa
+        await supabase.auth.signOut().catch(() => {});
+      });
+  } else {
+    await supabase.auth.signOut().catch(() => {
+      // Ignorar errores de cierre de sesión
+    });
+  }
+
+  const { data: existingProfileByEmail, error: lookupError } = await supabase
+    .from('perfiles')
+    .select('id')
+    .eq('email', normalizedEmail)
+    .maybeSingle();
+
+  if (lookupError) {
+    throw lookupError;
+  }
+
+  const profileId = authUserId ?? existingProfileByEmail?.id ?? null;
+
+  if (!profileId) {
+    throw new Error('No se pudo determinar el identificador del usuario registrado');
+  }
+
+  const payload = {
+    id: profileId,
+    email: normalizedEmail,
+    nombre_completo: fullName,
+    puesto,
+    rol_principal,
+    telefono,
+    estado: 'ACTIVO'
+  };
+
+  let data = null;
+
+  if (existingProfileByEmail) {
+    const { data: updatedProfile, error: updateError } = await supabase
+      .from('perfiles')
+      .update(payload)
+      .eq('id', existingProfileByEmail.id)
+      .select()
+      .single();
+
+    if (updateError) {
+      throw updateError;
+    }
+
+    data = updatedProfile;
+  } else {
+    const { data: createdProfile, error: createProfileError } = await supabase
+      .from('perfiles')
+      .insert(payload)
+      .select()
+      .single();
+
+    if (createProfileError) {
+      throw createProfileError;
+    }
+
+    data = createdProfile;
+  }
+
+  await supabase.auth
+    .resetPasswordForEmail(normalizedEmail)
+    .catch(() => {
+      // Si no se puede enviar el correo de restablecimiento no bloqueamos el alta
+    });
+
   return data;
 }
 

--- a/src/views/capture.js
+++ b/src/views/capture.js
@@ -4,6 +4,8 @@ import {
   getIndicatorHistory,
   getIndicatorTargets,
   saveMeasurement,
+  updateMeasurement,
+  validateMeasurement,
   upsertTarget
 } from '../services/supabaseClient.js';
 import { renderLoading, renderError, showToast } from '../ui/feedback.js';
@@ -23,7 +25,31 @@ let selectedAreaId = null;
 let selectedIndicatorId = null;
 let currentYear = new Date().getFullYear();
 
-function buildHistoryTable(history) {
+function formatValidationStatus(status) {
+  if (!status) return 'Pendiente';
+  const normalized = status.toString().trim().toUpperCase();
+  switch (normalized) {
+    case 'VALIDADO':
+      return 'Validado';
+    case 'RECHAZADO':
+      return 'Rechazado';
+    default:
+      return 'Pendiente';
+  }
+}
+
+function getStatusBadgeClass(status) {
+  switch ((status ?? '').toString().toUpperCase()) {
+    case 'VALIDADO':
+      return 'bg-emerald-100 text-emerald-700 border-emerald-200';
+    case 'RECHAZADO':
+      return 'bg-red-100 text-red-600 border-red-200';
+    default:
+      return 'bg-amber-100 text-amber-700 border-amber-200';
+  }
+}
+
+function buildHistoryTable(history, { showValidation = false } = {}) {
   if (!history.length) {
     return `
       <div class="bg-slate-50 border border-dashed border-slate-200 rounded-xl p-6 text-center text-sm text-slate-500">
@@ -49,17 +75,48 @@ function buildHistoryTable(history) {
             <th class="px-4 py-3 text-right font-semibold text-slate-500">Valor</th>
             <th class="px-4 py-3 text-left font-semibold text-slate-500">Escenario</th>
             <th class="px-4 py-3 text-right font-semibold text-slate-500">Capturado</th>
+            <th class="px-4 py-3 text-left font-semibold text-slate-500">Estatus</th>
+            ${showValidation ? '<th class="px-4 py-3 text-right font-semibold text-slate-500">Acciones</th>' : ''}
           </tr>
         </thead>
         <tbody class="divide-y divide-slate-100">
           ${sortedHistory
             .map((item) => {
+              const status = (item.estatus_validacion ?? '').toString().toUpperCase();
+              const badgeClass = getStatusBadgeClass(status);
+              const statusLabel = formatValidationStatus(status);
+              const canValidate = showValidation && status !== 'VALIDADO';
               return `
                 <tr>
                   <td class="px-4 py-3 text-slate-600">${monthName(item.mes)} ${item.anio}</td>
                   <td class="px-4 py-3 text-right font-semibold text-slate-800">${formatNumber(item.valor)}</td>
                   <td class="px-4 py-3 text-slate-500">${item.escenario ?? '—'}</td>
                   <td class="px-4 py-3 text-right text-slate-400 text-xs">${formatDate(item.fecha_captura ?? item.creado_en)}</td>
+                  <td class="px-4 py-3">
+                    <span class="inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold ${badgeClass}">
+                      ${statusLabel}
+                    </span>
+                    ${item.validado_por && item.fecha_validacion
+                      ? `<p class="mt-1 text-[11px] text-slate-400">Validado el ${formatDate(item.fecha_validacion)}</p>`
+                      : ''}
+                  </td>
+                  ${showValidation
+                    ? `
+                      <td class="px-4 py-3 text-right">
+                        ${canValidate
+                          ? `<button
+                              type="button"
+                              class="inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-emerald-700"
+                              data-action="validate"
+                              data-measurement-id="${item.id}"
+                            >
+                              <i class="fa-solid fa-shield-check"></i>
+                              Validar
+                            </button>`
+                          : '<span class="text-xs text-slate-400">—</span>'}
+                      </td>
+                    `
+                    : ''}
                 </tr>
               `;
             })
@@ -334,21 +391,53 @@ async function loadIndicatorContent(container, indicatorId) {
       getIndicatorTargets(indicatorId, { year: currentYear })
     ]);
 
-    // Calcular el siguiente mes a capturar
+    // Preparar catálogo de mediciones por mes del año seleccionado
+    const currentYearMeasurements = (history ?? []).filter(item => item.anio === currentYear);
+    const measurementsByMonth = new Map(
+      currentYearMeasurements.map(item => [Number(item.mes), item])
+    );
+
+    const capturedMonths = new Set(currentYearMeasurements.map(item => Number(item.mes)));
+    const availableMonths = months.filter(month => !capturedMonths.has(month.value));
+
+    // Calcular el siguiente mes sugerido
     let nextMonth = new Date().getMonth() + 1; // Mes actual por defecto
-    
+
     if (history && history.length > 0) {
-      // Encontrar el último mes capturado
-      const lastCapture = history[0]; // Ya está ordenado descendente
-      if (lastCapture.anio === currentYear) {
-        // Si hay capturas del año actual, sugerir el mes siguiente
-        nextMonth = (lastCapture.mes % 12) + 1;
-        // Si ya completó el año, volver a enero
-        if (lastCapture.mes === 12) {
+      const lastCapture = history[0];
+      if (lastCapture.anio === currentYear && lastCapture.mes) {
+        nextMonth = (Number(lastCapture.mes) % 12) + 1;
+        if (Number(lastCapture.mes) === 12) {
           nextMonth = 1;
         }
       }
     }
+
+    const disableCaptureForm = !esSubdirector && availableMonths.length === 0;
+    const suggestedMonth = esSubdirector
+      ? nextMonth
+      : availableMonths.length > 0
+        ? availableMonths[0].value
+        : nextMonth;
+
+    const initialMeasurement = esSubdirector ? measurementsByMonth.get(suggestedMonth) : null;
+    const initialValue = initialMeasurement ? initialMeasurement.valor ?? '' : '';
+    const initialButtonLabel = initialMeasurement ? 'Actualizar medición' : 'Guardar medición';
+
+    const monthOptions = months
+      .map((month) => {
+        const measurement = measurementsByMonth.get(month.value);
+        const isCaptured = Boolean(measurement);
+        const disabledAttr = !esSubdirector && isCaptured ? 'disabled' : '';
+        const selectedAttr = month.value === suggestedMonth ? 'selected' : '';
+        const statusLabel = isCaptured ? ` — ${formatNumber(measurement.valor)} (${formatValidationStatus(measurement.estatus_validacion)})` : '';
+        return `
+          <option value="${month.value}" ${selectedAttr} ${disabledAttr}>
+            ${month.label}${statusLabel}
+          </option>
+        `;
+      })
+      .join('');
 
     // Construcción dinámica: solo 1 columna si NO es subdirector, 2 columnas si SÍ es
     const gridClass = esSubdirector ? 'lg:grid-cols-2' : 'lg:grid-cols-1';
@@ -367,15 +456,20 @@ async function loadIndicatorContent(container, indicatorId) {
                 <p class="text-xs text-slate-500">${indicator.nombre}</p>
               </div>
             </div>
-            <form id="measurement-form" class="space-y-4">
+            <form
+              id="measurement-form"
+              class="space-y-4"
+              data-disable-capture="${disableCaptureForm ? 'true' : 'false'}"
+              data-editing-id="${initialMeasurement ? initialMeasurement.id : ''}"
+            >
               <label class="flex flex-col gap-1 text-sm text-slate-600">
                 Mes
-                <select name="month" class="rounded-lg border border-slate-200 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400">
-                  ${months.map((month) => `
-                    <option value="${month.value}" ${month.value === nextMonth ? 'selected' : ''}>
-                      ${month.label}
-                    </option>
-                  `).join('')}
+                <select
+                  name="month"
+                  class="rounded-lg border border-slate-200 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                  ${disableCaptureForm ? 'disabled' : ''}
+                >
+                  ${monthOptions}
                 </select>
               </label>
               <label class="flex flex-col gap-1 text-sm text-slate-600">
@@ -387,18 +481,31 @@ async function loadIndicatorContent(container, indicatorId) {
                   required
                   class="rounded-lg border border-slate-200 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
                   placeholder="Ingrese el valor"
+                  value="${initialValue}"
+                  ${disableCaptureForm && !esSubdirector ? 'disabled' : ''}
                 />
               </label>
-              <button type="submit" class="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700">
+              <button
+                type="submit"
+                class="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700"
+                ${disableCaptureForm && !esSubdirector ? 'disabled' : ''}
+              >
                 <i class="fa-solid fa-floppy-disk"></i>
-                Guardar medición
+                <span id="measurement-submit-label">${initialButtonLabel}</span>
               </button>
+              ${disableCaptureForm
+                ? `<p class="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-700">
+                    Todos los meses del ${currentYear} ya fueron capturados para este indicador. Contacte a su subdirección para realizar cambios.
+                  </p>`
+                : esSubdirector
+                  ? '<p class="text-[11px] text-slate-400">Seleccione un mes ya capturado para editarlo. Las actualizaciones quedarán registradas y deberán validarse nuevamente.</p>'
+                  : ''}
             </form>
           </div>
 
           <div class="space-y-3">
             <h3 class="text-sm font-semibold text-slate-600">Histórico de mediciones</h3>
-            <div id="history-table">${buildHistoryTable(history)}</div>
+            <div id="history-table">${buildHistoryTable(history, { showValidation: esSubdirector })}</div>
           </div>
         </div>
 
@@ -457,7 +564,7 @@ async function loadIndicatorContent(container, indicatorId) {
       </section>
     `;
 
-    initializeFormHandlers(indicatorId, esSubdirector);
+    initializeFormHandlers(indicatorId, esSubdirector, history, container);
   } catch (error) {
     console.error(error);
     container.innerHTML = '<div class="text-center py-8 text-red-500">Error al cargar el indicador</div>';
@@ -465,16 +572,72 @@ async function loadIndicatorContent(container, indicatorId) {
   }
 }
 
-function initializeFormHandlers(indicatorId, esSubdirector) {
+function initializeFormHandlers(indicatorId, esSubdirector, history, container) {
   const measurementForm = document.getElementById('measurement-form');
   const targetForm = document.getElementById('target-form');
   const historyTable = document.getElementById('history-table');
   const targetsTable = document.getElementById('targets-table');
+  const measurementSubmitLabel = document.getElementById('measurement-submit-label');
+
+  const measurementsByMonth = new Map(
+    (history ?? [])
+      .filter(item => item.anio === currentYear)
+      .map(item => [Number(item.mes), item])
+  );
 
   // Handler para formulario de mediciones
   if (measurementForm) {
+    const disableCapture = measurementForm.dataset.disableCapture === 'true';
+    const monthSelect = measurementForm.querySelector('select[name="month"]');
+    const valueInput = measurementForm.querySelector('input[name="value"]');
+    const submitButton = measurementForm.querySelector('button[type="submit"]');
+
+    if (disableCapture && !esSubdirector) {
+      measurementForm.querySelectorAll('input, select, button').forEach(element => {
+        element.disabled = true;
+      });
+    }
+
+    const syncFormWithMonth = () => {
+      if (!monthSelect || !valueInput || !submitButton) return;
+      const monthValue = Number(monthSelect.value);
+      const measurement = measurementsByMonth.get(monthValue);
+
+      if (esSubdirector && measurement) {
+        measurementForm.dataset.editingId = measurement.id ?? '';
+        valueInput.value = measurement.valor ?? '';
+        if (measurementSubmitLabel) {
+          measurementSubmitLabel.textContent = 'Actualizar medición';
+        }
+      } else {
+        measurementForm.dataset.editingId = '';
+        if (!disableCapture || esSubdirector) {
+          valueInput.value = '';
+        }
+        if (measurementSubmitLabel) {
+          measurementSubmitLabel.textContent = 'Guardar medición';
+        }
+      }
+    };
+
+    if (esSubdirector && monthSelect) {
+      monthSelect.addEventListener('change', syncFormWithMonth);
+      syncFormWithMonth();
+    } else if (monthSelect) {
+      monthSelect.addEventListener('change', () => {
+        measurementForm.dataset.editingId = '';
+        if (measurementSubmitLabel) {
+          measurementSubmitLabel.textContent = 'Guardar medición';
+        }
+      });
+    }
+
     measurementForm.addEventListener('submit', async (e) => {
       e.preventDefault();
+      if (disableCapture && !esSubdirector) {
+        showToast('Todos los meses del año seleccionado ya fueron capturados', { type: 'info' });
+        return;
+      }
       const submit = measurementForm.querySelector('button[type="submit"]');
       submit.disabled = true;
       submit.classList.add('opacity-70');
@@ -484,29 +647,41 @@ function initializeFormHandlers(indicatorId, esSubdirector) {
       const session = getSession();
       const userId = session?.user?.id;
 
-      const payload = {
-        indicador_id: indicatorId,
-        anio: currentYear,
-        mes: Number(formData.get('month')),
-        valor: Number(formData.get('value')),
-        capturado_por: userId
-        // escenario removido - la tabla mediciones no tiene esta columna
-      };
+      const editingId = measurementForm.dataset.editingId;
+      let shouldRestoreSubmit = true;
 
       try {
-        await saveMeasurement(payload);
-        showToast('Medición registrada correctamente');
-        measurementForm.reset();
-        
-        // Recargar histórico del año actual
-        const history = await getIndicatorHistory(indicatorId, { limit: 12, year: currentYear });
-        historyTable.innerHTML = buildHistoryTable(history);
+        if (editingId) {
+          await updateMeasurement(editingId, {
+            valor: Number(formData.get('value')),
+            editado_por: userId,
+            estatus_validacion: 'PENDIENTE'
+          });
+          showToast('Medición actualizada correctamente');
+        } else {
+          await saveMeasurement({
+            indicador_id: indicatorId,
+            anio: currentYear,
+            mes: Number(formData.get('month')),
+            valor: Number(formData.get('value')),
+            capturado_por: userId
+          });
+          showToast('Medición registrada correctamente');
+        }
+
+        shouldRestoreSubmit = false;
+        submit.disabled = false;
+        submit.classList.remove('opacity-70');
+        await loadIndicatorContent(container, indicatorId);
+        return;
       } catch (error) {
         console.error(error);
         showToast(error.message ?? 'No fue posible registrar la medición', { type: 'error' });
       } finally {
-        submit.disabled = false;
-        submit.classList.remove('opacity-70');
+        if (shouldRestoreSubmit) {
+          submit.disabled = false;
+          submit.classList.remove('opacity-70');
+        }
       }
     });
   }
@@ -543,6 +718,34 @@ function initializeFormHandlers(indicatorId, esSubdirector) {
       } finally {
         submit.disabled = false;
         submit.classList.remove('opacity-70');
+      }
+    });
+  }
+
+  if (historyTable && esSubdirector) {
+    historyTable.addEventListener('click', async (event) => {
+      const button = event.target.closest('button[data-action="validate"]');
+      if (!button) return;
+      const measurementId = button.dataset.measurementId;
+      if (!measurementId) return;
+
+      const originalContent = button.innerHTML;
+      button.disabled = true;
+      button.classList.add('opacity-70');
+      button.innerHTML = '<i class="fa-solid fa-spinner fa-spin"></i> Validando...';
+
+      try {
+        const session = getSession();
+        const userId = session?.user?.id ?? null;
+        await validateMeasurement(measurementId, { validado_por: userId });
+        showToast('Medición validada correctamente');
+        await loadIndicatorContent(container, indicatorId);
+      } catch (error) {
+        console.error(error);
+        showToast(error.message ?? 'No fue posible validar la medición', { type: 'error' });
+        button.disabled = false;
+        button.classList.remove('opacity-70');
+        button.innerHTML = originalContent;
       }
     });
   }

--- a/src/views/users.js
+++ b/src/views/users.js
@@ -1,4 +1,13 @@
-import { getAllUsers, updateUser, deactivateUser, assignUserToArea, removeUserFromArea, getAreas } from '../services/supabaseClient.js';
+import {
+  getAllUsers,
+  updateUser,
+  deactivateUser,
+  assignUserToArea,
+  removeUserFromArea,
+  updateUserAreaPermissions,
+  getAreas,
+  createUser
+} from '../services/supabaseClient.js';
 import { formatDate } from '../utils/formatters.js';
 import { showToast, renderLoading, renderError } from '../ui/feedback.js';
 
@@ -7,7 +16,6 @@ const ESTADOS = ['ACTIVO', 'INACTIVO'];
 
 let currentUsers = [];
 let currentAreas = [];
-let selectedUser = null;
 
 function escapeHtml(value) {
   if (value == null) return '';
@@ -114,6 +122,102 @@ function buildUsersTable(users, searchTerm = '') {
       `
     )
     .join('');
+}
+
+function buildCreateModal() {
+  return `
+    <div class="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/50 px-4" data-modal="create-user">
+      <div class="w-full max-w-lg rounded-2xl bg-white p-6 shadow-xl">
+        <div class="mb-4 flex items-center justify-between">
+          <div>
+            <h3 class="text-lg font-semibold text-slate-800">Registrar nuevo usuario</h3>
+            <p class="text-xs text-slate-500">
+              Al guardar enviaremos un correo para que la persona establezca su contraseña y active su acceso.
+            </p>
+          </div>
+          <button type="button" class="text-slate-400 hover:text-slate-600" data-modal-close>
+            <i class="fa-solid fa-xmark text-xl"></i>
+          </button>
+        </div>
+
+        <form id="create-user-form" class="space-y-4">
+          <div>
+            <label class="block text-sm font-medium text-slate-700 mb-1">Nombre completo</label>
+            <input
+              type="text"
+              name="nombre_completo"
+              required
+              class="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-100"
+            />
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-slate-700 mb-1">Correo electrónico</label>
+            <input
+              type="email"
+              name="email"
+              required
+              class="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-100"
+            />
+            <p class="mt-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-700">
+              La contraseña inicial se generará automáticamente tomando todo lo anterior al símbolo <span class="font-semibold">@</span>
+              del correo y agregando <span class="font-semibold">1544</span> (por ejemplo: <span class="font-mono">usuario1544</span>). Solicita que el usuario la cambie al iniciar sesión.
+            </p>
+          </div>
+
+          <div class="grid grid-cols-2 gap-4">
+            <div>
+              <label class="block text-sm font-medium text-slate-700 mb-1">Puesto</label>
+              <input
+                type="text"
+                name="puesto"
+                class="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-100"
+              />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-slate-700 mb-1">Teléfono</label>
+              <input
+                type="tel"
+                name="telefono"
+                class="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-100"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-slate-700 mb-1">Rol principal</label>
+            <select
+              name="rol_principal"
+              required
+              class="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-100"
+            >
+              <option value="">Seleccionar rol</option>
+              ${ROLES.map(rol => `
+                <option value="${rol}">${rol}</option>
+              `).join('')}
+            </select>
+          </div>
+
+          <div class="flex gap-3 pt-2">
+            <button
+              type="submit"
+              class="flex-1 rounded-lg bg-primary-600 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-700"
+            >
+              <i class="fa-solid fa-user-plus mr-2"></i>
+              Registrar usuario
+            </button>
+            <button
+              type="button"
+              data-modal-close
+              class="rounded-lg border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 hover:bg-slate-50"
+            >
+              Cancelar
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  `;
 }
 
 function buildEditModal(user) {
@@ -243,26 +347,41 @@ function buildAreasModal(user) {
           <h4 class="text-sm font-semibold text-slate-700 mb-2">Áreas asignadas</h4>
           <div class="space-y-2" id="assigned-areas">
             ${user.areas.length ? user.areas.map(ua => `
-              <div class="flex items-center justify-between rounded-lg border border-slate-200 bg-slate-50 p-3">
+              <div class="flex flex-col gap-3 rounded-lg border border-slate-200 bg-slate-50 p-3 sm:flex-row sm:items-center sm:justify-between">
                 <div class="flex-1">
                   <p class="font-medium text-slate-800">${escapeHtml(ua.areas?.nombre || 'Área desconocida')}</p>
-                  <p class="text-xs text-slate-500">Rol: ${escapeHtml(ua.rol)}</p>
-                  <div class="mt-1 flex gap-2 text-xs">
-                    ${ua.puede_capturar ? '<span class="text-blue-600">✓ Captura</span>' : '<span class="text-slate-400">✗ Captura</span>'}
-                    ${ua.puede_editar ? '<span class="text-amber-600">✓ Edición</span>' : '<span class="text-slate-400">✗ Edición</span>'}
-                    ${ua.puede_eliminar ? '<span class="text-red-600">✓ Eliminación</span>' : '<span class="text-slate-400">✗ Eliminación</span>'}
+                  <p class="text-xs text-slate-500">Rol: ${escapeHtml(ua.rol || 'Sin rol')}</p>
+                  <div class="mt-1 flex flex-wrap gap-2 text-xs">
+                    ${ua.puede_capturar ? '<span class="rounded bg-blue-100 px-2 py-0.5 text-blue-700">✓ Captura</span>' : '<span class="text-slate-400">✗ Captura</span>'}
+                    ${ua.puede_editar ? '<span class="rounded bg-amber-100 px-2 py-0.5 text-amber-700">✓ Edición</span>' : '<span class="text-slate-400">✗ Edición</span>'}
+                    ${ua.puede_eliminar ? '<span class="rounded bg-red-100 px-2 py-0.5 text-red-700">✓ Eliminación</span>' : '<span class="text-slate-400">✗ Eliminación</span>'}
                   </div>
                 </div>
-                <button
-                  type="button"
-                  class="ml-4 text-red-600 hover:text-red-700"
-                  data-action="remove-area"
-                  data-usuario-id="${user.id}"
-                  data-area-id="${ua.area_id}"
-                  title="Remover área"
-                >
-                  <i class="fa-solid fa-trash"></i>
-                </button>
+                <div class="flex items-center gap-2 sm:ml-4">
+                  <button
+                    type="button"
+                    class="rounded-lg border border-primary-100 px-3 py-1.5 text-sm font-medium text-primary-600 hover:bg-primary-50"
+                    data-action="edit-area"
+                    data-usuario-id="${user.id}"
+                    data-assignment-id="${ua.id}"
+                    title="Editar asignación"
+                  >
+                    <i class="fa-solid fa-pen-to-square mr-1"></i>
+                    Editar
+                  </button>
+                  <button
+                    type="button"
+                    class="rounded-lg border border-red-100 px-3 py-1.5 text-sm font-medium text-red-600 hover:bg-red-50"
+                    data-action="remove-area"
+                    data-usuario-id="${user.id}"
+                    data-area-id="${ua.area_id}"
+                    data-assignment-id="${ua.id}"
+                    title="Remover área"
+                  >
+                    <i class="fa-solid fa-trash mr-1"></i>
+                    Quitar
+                  </button>
+                </div>
               </div>
             `).join('') : '<p class="text-sm text-slate-400 py-4 text-center">No tiene áreas asignadas</p>'}
           </div>
@@ -323,6 +442,90 @@ function buildAreasModal(user) {
             </button>
           </form>
         </div>
+      </div>
+    </div>
+  `;
+}
+
+function buildEditAreaModal(user, assignment) {
+  return `
+    <div class="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/50 px-4" data-modal="edit-area">
+      <div class="w-full max-w-xl rounded-2xl bg-white p-6 shadow-xl">
+        <div class="mb-4 flex items-center justify-between">
+          <div>
+            <h3 class="text-lg font-semibold text-slate-800">Editar área asignada</h3>
+            <p class="text-sm text-slate-500">${escapeHtml(user.nombre_completo)}</p>
+          </div>
+          <button type="button" class="text-slate-400 hover:text-slate-600" data-modal-close>
+            <i class="fa-solid fa-xmark text-xl"></i>
+          </button>
+        </div>
+
+        <form id="edit-area-form" class="space-y-4">
+          <input type="hidden" name="usuario_area_id" value="${assignment.id}" />
+          <input type="hidden" name="usuario_id" value="${user.id}" />
+
+          <div>
+            <label class="block text-xs font-medium text-slate-700 mb-1">Área asignada</label>
+            <select
+              name="area_id"
+              required
+              class="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-100"
+            >
+              <option value="">Seleccionar área</option>
+              ${currentAreas.map(area => `
+                <option value="${area.id}" ${String(area.id) === String(assignment.area_id) ? 'selected' : ''}>
+                  ${escapeHtml(area.nombre)}
+                </option>
+              `).join('')}
+            </select>
+          </div>
+
+          <div>
+            <label class="block text-xs font-medium text-slate-700 mb-1">Rol en área</label>
+            <select
+              name="rol"
+              required
+              class="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-100"
+            >
+              ${ROLES.map(rol => `
+                <option value="${rol}" ${assignment.rol === rol ? 'selected' : ''}>${rol}</option>
+              `).join('')}
+            </select>
+          </div>
+
+          <div class="flex flex-wrap gap-4">
+            <label class="flex items-center gap-2 text-sm text-slate-700">
+              <input type="checkbox" name="puede_capturar" ${assignment.puede_capturar ? 'checked' : ''} class="rounded border-slate-300 text-primary-600" />
+              Puede capturar
+            </label>
+            <label class="flex items-center gap-2 text-sm text-slate-700">
+              <input type="checkbox" name="puede_editar" ${assignment.puede_editar ? 'checked' : ''} class="rounded border-slate-300 text-primary-600" />
+              Puede editar
+            </label>
+            <label class="flex items-center gap-2 text-sm text-slate-700">
+              <input type="checkbox" name="puede_eliminar" ${assignment.puede_eliminar ? 'checked' : ''} class="rounded border-slate-300 text-primary-600" />
+              Puede eliminar
+            </label>
+          </div>
+
+          <div class="flex gap-3 pt-2">
+            <button
+              type="submit"
+              class="flex-1 rounded-lg bg-primary-600 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-700"
+            >
+              <i class="fa-solid fa-floppy-disk mr-2"></i>
+              Guardar cambios
+            </button>
+            <button
+              type="button"
+              data-modal-close
+              class="rounded-lg border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 hover:bg-slate-50"
+            >
+              Cancelar
+            </button>
+          </div>
+        </form>
       </div>
     </div>
   `;
@@ -416,9 +619,8 @@ function initializeEventListeners() {
   // Botón nuevo usuario
   if (newUserButton) {
     newUserButton.addEventListener('click', () => {
-      showToast('Para crear un nuevo usuario, primero debe crearse en Supabase Authentication', { 
-        type: 'warning' 
-      });
+      modalContainer.innerHTML = buildCreateModal();
+      bindModalActions();
     });
   }
 
@@ -475,14 +677,60 @@ function initializeEventListeners() {
 
   function bindModalActions() {
     // Cerrar modal
-    document.querySelectorAll('[data-modal-close]').forEach(btn => {
+    modalContainer.querySelectorAll('[data-modal-close]').forEach(btn => {
       btn.addEventListener('click', () => {
         modalContainer.innerHTML = '';
       });
     });
 
+    const createForm = modalContainer.querySelector('#create-user-form');
+    if (createForm) {
+      createForm.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const formData = new FormData(e.target);
+        const payload = {
+          nombre_completo: formData.get('nombre_completo')?.trim(),
+          email: formData.get('email')?.trim(),
+          puesto: formData.get('puesto')?.trim() || null,
+          telefono: formData.get('telefono')?.trim() || null,
+          rol_principal: formData.get('rol_principal')
+        };
+
+        const submitButton = createForm.querySelector('button[type="submit"]');
+        const originalLabel = submitButton?.innerHTML;
+
+        if (submitButton) {
+          submitButton.disabled = true;
+          submitButton.innerHTML = '<i class="fa-solid fa-spinner fa-spin mr-2"></i>Guardando...';
+        }
+
+        try {
+          await createUser(payload);
+          showToast('Usuario creado correctamente');
+          modalContainer.innerHTML = '';
+          currentUsers = await getAllUsers();
+          tableBody.innerHTML = buildUsersTable(currentUsers);
+          bindTableActions();
+        } catch (error) {
+          console.error(error);
+          let message = 'No fue posible crear el usuario';
+          if (error?.code === '23505' || /duplicate/i.test(error?.message ?? '')) {
+            message = 'Ya existe un usuario registrado con ese correo electrónico';
+          } else if (/correo electr[oó]nico es obligatorio/i.test(error?.message ?? '')) {
+            message = 'Debe capturar un correo electrónico válido';
+          }
+          showToast(message, { type: 'error' });
+        } finally {
+          if (submitButton) {
+            submitButton.disabled = false;
+            submitButton.innerHTML = originalLabel;
+          }
+        }
+      });
+    }
+
     // Form editar usuario
-    const editForm = document.getElementById('edit-user-form');
+    const editForm = modalContainer.querySelector('#edit-user-form');
     if (editForm) {
       editForm.addEventListener('submit', async (e) => {
         e.preventDefault();
@@ -512,7 +760,7 @@ function initializeEventListeners() {
     }
 
     // Form asignar área
-    const assignForm = document.getElementById('assign-area-form');
+    const assignForm = modalContainer.querySelector('#assign-area-form');
     if (assignForm) {
       assignForm.addEventListener('submit', async (e) => {
         e.preventDefault();
@@ -529,19 +777,79 @@ function initializeEventListeners() {
         try {
           await assignUserToArea(payload);
           showToast('Área asignada correctamente');
-          modalContainer.innerHTML = '';
           currentUsers = await getAllUsers();
           tableBody.innerHTML = buildUsersTable(currentUsers);
           bindTableActions();
+
+          const updatedUser = currentUsers.find(u => String(u.id) === String(payload.usuario_id));
+          if (updatedUser) {
+            modalContainer.innerHTML = buildAreasModal(updatedUser);
+            bindModalActions();
+          } else {
+            modalContainer.innerHTML = '';
+          }
         } catch (error) {
           console.error(error);
           showToast('No fue posible asignar el área', { type: 'error' });
         }
       });
     }
-  }
-// Remover área (AGREGAR ESTE CÓDIGO)
-    document.querySelectorAll('[data-action="remove-area"]').forEach(btn => {
+
+    const editAreaForm = modalContainer.querySelector('#edit-area-form');
+    if (editAreaForm) {
+      editAreaForm.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const formData = new FormData(e.target);
+        const usuarioAreaId = formData.get('usuario_area_id');
+        const usuarioId = formData.get('usuario_id');
+        const updates = {
+          area_id: formData.get('area_id'),
+          rol: formData.get('rol'),
+          puede_capturar: formData.get('puede_capturar') === 'on',
+          puede_editar: formData.get('puede_editar') === 'on',
+          puede_eliminar: formData.get('puede_eliminar') === 'on',
+          estado: 'ACTIVO'
+        };
+
+        try {
+          await updateUserAreaPermissions(usuarioAreaId, updates);
+          showToast('Área actualizada correctamente');
+          currentUsers = await getAllUsers();
+          tableBody.innerHTML = buildUsersTable(currentUsers);
+          bindTableActions();
+
+          const updatedUser = currentUsers.find(u => String(u.id) === String(usuarioId));
+          if (updatedUser) {
+            modalContainer.innerHTML = buildAreasModal(updatedUser);
+            bindModalActions();
+          } else {
+            modalContainer.innerHTML = '';
+          }
+        } catch (error) {
+          console.error(error);
+          showToast('No fue posible actualizar el área', { type: 'error' });
+        }
+      });
+    }
+
+    modalContainer.querySelectorAll('[data-action="edit-area"]').forEach(btn => {
+      btn.addEventListener('click', (e) => {
+        const usuarioId = e.currentTarget.dataset.usuarioId;
+        const assignmentId = e.currentTarget.dataset.assignmentId;
+        const user = currentUsers.find(u => String(u.id) === String(usuarioId));
+        if (!user) return;
+
+        const assignment = user.areas?.find(ua => String(ua.id) === String(assignmentId))
+          || user.areas?.find(ua => String(ua.area_id) === String(assignmentId));
+
+        if (!assignment) return;
+
+        modalContainer.innerHTML = buildEditAreaModal(user, assignment);
+        bindModalActions();
+      });
+    });
+
+    modalContainer.querySelectorAll('[data-action="remove-area"]').forEach(btn => {
       btn.addEventListener('click', async (e) => {
         const usuarioId = e.currentTarget.dataset.usuarioId;
         const areaId = e.currentTarget.dataset.areaId;
@@ -550,10 +858,17 @@ function initializeEventListeners() {
           try {
             await removeUserFromArea(usuarioId, areaId);
             showToast('Área removida correctamente');
-            modalContainer.innerHTML = '';
             currentUsers = await getAllUsers();
             tableBody.innerHTML = buildUsersTable(currentUsers);
             bindTableActions();
+
+            const updatedUser = currentUsers.find(u => String(u.id) === String(usuarioId));
+            if (updatedUser) {
+              modalContainer.innerHTML = buildAreasModal(updatedUser);
+              bindModalActions();
+            } else {
+              modalContainer.innerHTML = '';
+            }
           } catch (error) {
             console.error(error);
             showToast('No fue posible remover el área', { type: 'error' });
@@ -561,4 +876,5 @@ function initializeEventListeners() {
         }
       });
     });
-  } // ← Este es el cierre de bindModalActions
+  }
+}


### PR DESCRIPTION
## Summary
- generate the initial password automatically from the email prefix plus 1544 when creating users from the admin module
- clarify the default credential rule in the user registration modal copy
- replace the top-bar sign-out button with an account dropdown and change-password modal that validates password complexity before updating Supabase Auth

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0118537b0832e83c86f1ee3341709