### PR TITLE
Ensure validation status persists after approval

### DIFF
--- a/src/lib/supabaseClient.js
+++ b/src/lib/supabaseClient.js
@@ -27,31 +27,65 @@ function normalizeStatus(value) {
     : text;
 }
 
-function normalizeMeasurement(record) {
+const VALIDATION_STATES = ['PENDIENTE', 'VALIDADO', 'RECHAZADO'];
+
+function normalizeValidationStatus(value) {
+  if (value === null || value === undefined) return null;
+  const normalized = value.toString().trim().toUpperCase();
+  if (!normalized) return null;
+  if (VALIDATION_STATES.includes(normalized)) return normalized;
+  if (normalized === 'APROBADO') return 'VALIDADO';
+  if (normalized === 'RECHAZADA') return 'RECHAZADO';
+  return normalized;
+}
+
+function syncValidationFields(record, fallbackStatus) {
   if (!record) return record;
-  const status =
+  const candidateStatus =
     record.estatus_validacion ??
     record.estado_validacion ??
     record.estatus ??
+    record.estado ??
     (typeof record.validado === 'boolean'
       ? record.validado
         ? 'VALIDADO'
         : 'PENDIENTE'
-      : null);
-
+      : null) ??
+    fallbackStatus ??
+    null;
+  const status = normalizeValidationStatus(candidateStatus);
+  if (!status) return record;
   return {
     ...record,
-    escenario: record.escenario ? record.escenario.toUpperCase() : null,
+    estatus_validacion: status,
+    estado_validacion: status,
+    estatus: status,
+    estado: status,
+    validado: status === 'VALIDADO'
+  };
+}
+
+function normalizeMeasurement(record) {
+  if (!record) return record;
+  const normalizedRecord = syncValidationFields(record);
+  const status = normalizedRecord.estatus_validacion;
+
+  return {
+    ...normalizedRecord,
+    escenario: normalizedRecord.escenario ? normalizedRecord.escenario.toUpperCase() : null,
     estatus_validacion: typeof status === 'string' ? status.toUpperCase() : status ?? 'PENDIENTE',
-    fecha_captura: record.fecha_captura ?? record.creado_en ?? null,
+    fecha_captura: normalizedRecord.fecha_captura ?? normalizedRecord.creado_en ?? null,
     fecha_actualizacion:
-      record.fecha_actualizacion ?? record.fecha_ultima_edicion ?? record.actualizado_en ?? null,
-    fecha_validacion: record.fecha_validacion ?? record.validado_en ?? null,
-    validado_por: record.validado_por ?? record.subdirector_id ?? null,
+      normalizedRecord.fecha_actualizacion ??
+      normalizedRecord.fecha_ultima_edicion ??
+      normalizedRecord.actualizado_en ??
+      null,
+    fecha_validacion: normalizedRecord.fecha_validacion ?? normalizedRecord.validado_en ?? null,
+    validado_por: normalizedRecord.validado_por ?? normalizedRecord.subdirector_id ?? null,
     observaciones_validacion:
-      record.observaciones_validacion ?? record.validacion_observaciones ?? null,
-    capturado_por: record.capturado_por ?? record.creado_por ?? null,
-    editado_por: record.editado_por ?? record.actualizado_por ?? null
+      normalizedRecord.observaciones_validacion ?? normalizedRecord.validacion_observaciones ?? null,
+    capturado_por: normalizedRecord.capturado_por ?? normalizedRecord.creado_por ?? null,
+    editado_por: normalizedRecord.editado_por ?? normalizedRecord.actualizado_por ?? null
   };
 }
 
@@ -298,12 +332,14 @@ export async function getIndicatorTargets(indicadorId, { year } = {}) {
 }
 
 export async function saveMeasurement(payload) {
-  const sanitized = sanitizeScenario(payload ? { ...payload } : payload);
-  if (sanitized && !('estatus_validacion' in sanitized)) {
-    sanitized.estatus_validacion = 'PENDIENTE';
-  }
-  if (sanitized && typeof sanitized.estatus_validacion === 'string') {
-    sanitized.estatus_validacion = sanitized.estatus_validacion.toUpperCase();
+  let sanitized = sanitizeScenario(payload ? { ...payload } : payload);
+  sanitized = syncValidationFields(sanitized, 'PENDIENTE');
+  if (sanitized && sanitized.estatus_validacion !== 'VALIDADO') {
+    sanitized = {
+      ...sanitized,
+      validado_por: null,
+      fecha_validacion: null
+    };
   }
   const { data, error } = await supabase.from('mediciones').insert(sanitized).select().single();
   if (error) throw error;
@@ -311,9 +347,14 @@ export async function saveMeasurement(payload) {
 }
 
 export async function updateMeasurement(id, payload) {
-  const sanitized = sanitizeScenario(payload ? { ...payload } : payload);
-  if (sanitized && typeof sanitized.estatus_validacion === 'string') {
-    sanitized.estatus_validacion = sanitized.estatus_validacion.toUpperCase();
+  let sanitized = sanitizeScenario(payload ? { ...payload } : payload);
+  sanitized = syncValidationFields(sanitized);
+  if (sanitized && sanitized.estatus_validacion !== 'VALIDADO') {
+    sanitized = {
+      ...sanitized,
+      validado_por: sanitized.validado_por ?? null,
+      fecha_validacion: sanitized.fecha_validacion ?? null
+    };
   }
   const { data, error } = await supabase
     .from('mediciones')
@@ -327,11 +368,12 @@ export async function updateMeasurement(id, payload) {
 
 export async function validateMeasurement(id, { validado_por, observaciones = null } = {}) {
   if (!id) throw new Error('Se requiere un identificador de medición para validar.');
-  const payload = {
+  let payload = {
     estatus_validacion: 'VALIDADO',
     validado_por: validado_por ?? null,
     fecha_validacion: new Date().toISOString()
   };
+  payload = syncValidationFields(payload, 'VALIDADO');
   if (observaciones !== undefined) {
     payload.observaciones_validacion = observaciones;
   }

--- a/src/pages/CapturePage.jsx
+++ b/src/pages/CapturePage.jsx
@@ -159,9 +159,17 @@ export default function CapturePage() {
   const queryClient = useQueryClient();
   const indicatorsQuery = useQuery({ queryKey: ['indicators'], queryFn: getIndicators });
 
-  const roleLabel = (profile?.rol ?? profile?.puesto ?? '').toString().toLowerCase();
-  const isAdmin = roleLabel.includes('admin');
-  const isSubdirector = roleLabel.includes('subdirector');
+  const roleLabel = (
+    profile?.rol_principal ?? profile?.rol ?? profile?.puesto ?? ''
+  )
+    .toString()
+    .toLowerCase();
+  const normalizedRoleLabel =
+    typeof roleLabel.normalize === 'function'
+      ? roleLabel.normalize('nfd').replace(/[\u0300-\u036f]/g, '')
+      : roleLabel;
+  const isAdmin = normalizedRoleLabel.includes('admin');
+  const isSubdirector = /subdirector|director/.test(normalizedRoleLabel);
   const canValidate = isAdmin || isSubdirector;
   const canManageTargets = isAdmin || isSubdirector;
 

--- a/src/services/supabaseClient.js
+++ b/src/services/supabaseClient.js
@@ -27,31 +27,65 @@ function normalizeStatus(value) {
     : text;
 }
 
-function normalizeMeasurement(record) {
+const VALIDATION_STATES = ['PENDIENTE', 'VALIDADO', 'RECHAZADO'];
+
+function normalizeValidationStatus(value) {
+  if (value === null || value === undefined) return null;
+  const normalized = value.toString().trim().toUpperCase();
+  if (!normalized) return null;
+  if (VALIDATION_STATES.includes(normalized)) return normalized;
+  if (normalized === 'APROBADO') return 'VALIDADO';
+  if (normalized === 'RECHAZADA') return 'RECHAZADO';
+  return normalized;
+}
+
+function syncValidationFields(record, fallbackStatus) {
   if (!record) return record;
-  const status =
+  const candidateStatus =
     record.estatus_validacion ??
     record.estado_validacion ??
     record.estatus ??
+    record.estado ??
     (typeof record.validado === 'boolean'
       ? record.validado
         ? 'VALIDADO'
         : 'PENDIENTE'
-      : null);
-
+      : null) ??
+    fallbackStatus ??
+    null;
+  const status = normalizeValidationStatus(candidateStatus);
+  if (!status) return record;
   return {
     ...record,
-    escenario: record.escenario ? record.escenario.toUpperCase() : null,
+    estatus_validacion: status,
+    estado_validacion: status,
+    estatus: status,
+    estado: status,
+    validado: status === 'VALIDADO'
+  };
+}
+
+function normalizeMeasurement(record) {
+  if (!record) return record;
+  const normalizedRecord = syncValidationFields(record);
+  const status = normalizedRecord.estatus_validacion;
+
+  return {
+    ...normalizedRecord,
+    escenario: normalizedRecord.escenario ? normalizedRecord.escenario.toUpperCase() : null,
     estatus_validacion: typeof status === 'string' ? status.toUpperCase() : status ?? 'PENDIENTE',
-    fecha_captura: record.fecha_captura ?? record.creado_en ?? null,
+    fecha_captura: normalizedRecord.fecha_captura ?? normalizedRecord.creado_en ?? null,
     fecha_actualizacion:
-      record.fecha_actualizacion ?? record.fecha_ultima_edicion ?? record.actualizado_en ?? null,
-    fecha_validacion: record.fecha_validacion ?? record.validado_en ?? null,
-    validado_por: record.validado_por ?? record.subdirector_id ?? null,
+      normalizedRecord.fecha_actualizacion ??
+      normalizedRecord.fecha_ultima_edicion ??
+      normalizedRecord.actualizado_en ??
+      null,
+    fecha_validacion: normalizedRecord.fecha_validacion ?? normalizedRecord.validado_en ?? null,
+    validado_por: normalizedRecord.validado_por ?? normalizedRecord.subdirector_id ?? null,
     observaciones_validacion:
-      record.observaciones_validacion ?? record.validacion_observaciones ?? null,
-    capturado_por: record.capturado_por ?? record.creado_por ?? null,
-    editado_por: record.editado_por ?? record.actualizado_por ?? null
+      normalizedRecord.observaciones_validacion ?? normalizedRecord.validacion_observaciones ?? null,
+    capturado_por: normalizedRecord.capturado_por ?? normalizedRecord.creado_por ?? null,
+    editado_por: normalizedRecord.editado_por ?? normalizedRecord.actualizado_por ?? null
   };
 }
 
@@ -366,12 +400,14 @@ export async function getIndicatorTargets(indicadorId, { year } = {}) {
 }
 
 export async function saveMeasurement(payload) {
-  const sanitized = sanitizeScenario(payload ? { ...payload } : payload);
-  if (sanitized && !('estatus_validacion' in sanitized)) {
-    sanitized.estatus_validacion = 'PENDIENTE';
-  }
-  if (sanitized && typeof sanitized.estatus_validacion === 'string') {
-    sanitized.estatus_validacion = sanitized.estatus_validacion.toUpperCase();
+  let sanitized = sanitizeScenario(payload ? { ...payload } : payload);
+  sanitized = syncValidationFields(sanitized, 'PENDIENTE');
+  if (sanitized && sanitized.estatus_validacion !== 'VALIDADO') {
+    sanitized = {
+      ...sanitized,
+      validado_por: null,
+      fecha_validacion: null
+    };
   }
   const { data, error } = await supabase.from('mediciones').insert(sanitized).select().single();
   if (error) throw error;
@@ -379,9 +415,14 @@ export async function saveMeasurement(payload) {
 }
 
 export async function updateMeasurement(id, payload) {
-  const sanitized = sanitizeScenario(payload ? { ...payload } : payload);
-  if (sanitized && typeof sanitized.estatus_validacion === 'string') {
-    sanitized.estatus_validacion = sanitized.estatus_validacion.toUpperCase();
+  let sanitized = sanitizeScenario(payload ? { ...payload } : payload);
+  sanitized = syncValidationFields(sanitized);
+  if (sanitized && sanitized.estatus_validacion !== 'VALIDADO') {
+    sanitized = {
+      ...sanitized,
+      validado_por: sanitized.validado_por ?? null,
+      fecha_validacion: sanitized.fecha_validacion ?? null
+    };
   }
   const { data, error } = await supabase
     .from('mediciones')
@@ -395,11 +436,12 @@ export async function updateMeasurement(id, payload) {
 
 export async function validateMeasurement(id, { validado_por, observaciones = null } = {}) {
   if (!id) throw new Error('Se requiere un identificador de medición para validar.');
-  const payload = {
+  let payload = {
     estatus_validacion: 'VALIDADO',
     validado_por: validado_por ?? null,
     fecha_validacion: new Date().toISOString()
   };
+  payload = syncValidationFields(payload, 'VALIDADO');
   if (observaciones !== undefined) {
     payload.observaciones_validacion = observaciones;
   }

--- a/src/views/capture.js
+++ b/src/views/capture.js
@@ -376,8 +376,14 @@ async function loadIndicatorContent(container, indicatorId) {
 
   try {
     const session = getSession();
-    const userRole = session?.perfil?.rol_principal || session?.perfil?.rol || 'usuario';
-    const esSubdirector = userRole?.toLowerCase().includes('subdirector');
+    const rawRole =
+      session?.perfil?.rol_principal || session?.perfil?.rol || session?.perfil?.puesto || 'usuario';
+    const lowerCaseRole = rawRole.toString().toLowerCase();
+    const normalizedRole =
+      typeof lowerCaseRole.normalize === 'function'
+        ? lowerCaseRole.normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+        : lowerCaseRole;
+    const esSubdirector = /subdirector|director|admin/.test(normalizedRole);
     
     const indicator = currentIndicators.find(ind => ind.id === indicatorId);
     

--- a/src/views/dashboard.js
+++ b/src/views/dashboard.js
@@ -1051,15 +1051,15 @@ function buildChartConfig(realData, type, scenario, chartType = 'line', showHist
 }
 
 // Función buildChartTypeToggle corregida
-// CAMBIO: Ahora también muestra el toggle para 'quarterly' y 'annual'
+// CAMBIO: Ahora también muestra el toggle para 'monthly'
 
 function buildChartTypeToggle(currentType, type) {
-  // Mostrar toggle para todos EXCEPTO monthly (que solo usa líneas)
-  // Entonces: quarterly, annual y scenario tendrán el toggle
-  if (type === 'monthly') {
+  const supportedTypes = new Set(['monthly', 'quarterly', 'annual', 'scenario']);
+
+  if (!supportedTypes.has(type)) {
     return '';
   }
-  
+
   return `
     <div class="inline-flex rounded-full border border-slate-200 bg-white p-1 shadow-sm" data-chart-toggle>
       <button


### PR DESCRIPTION
## Summary
- normalize stored role labels before checking validation permissions
- allow directors and administrators to validate measurements in both the SPA and legacy capture views
- synchronize all validation status fields so approved measurements stay marked as validated instead of reverting to pending

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3d1155730832e9a608cae99dcb0c4