### PR TITLE
feat: add bulk target update action

### DIFF
--- a/src/views/capture.js
+++ b/src/views/capture.js
@@ -17,6 +17,8 @@ const months = Array.from({ length: 12 }).map((_, index) => ({
   label: monthName(index + 1)
 }));
 
+const TARGET_YEARS = Array.from({ length: 11 }).map((_, index) => 2022 + index);
+
 const SCENARIOS = ['BAJO', 'MEDIO', 'ALTO'];
 
 let currentAreas = [];
@@ -127,43 +129,49 @@ function buildHistoryTable(history, { showValidation = false } = {}) {
   `;
 }
 
-function buildTargetsTable(targets) {
-  if (!targets.length) {
-    return `
-      <div class="bg-slate-50 border border-dashed border-slate-200 rounded-xl p-6 text-center text-sm text-slate-500">
-        No hay metas registradas para este indicador.
-      </div>
-    `;
-  }
-  
-  return `
-    <div class="overflow-x-auto rounded-xl border border-slate-200 bg-white shadow-sm">
-      <table class="min-w-full divide-y divide-slate-200 text-sm">
-        <thead class="bg-slate-50">
-          <tr>
-            <th class="px-4 py-3 text-left font-semibold text-slate-500">Periodo</th>
-            <th class="px-4 py-3 text-right font-semibold text-slate-500">Meta</th>
-            <th class="px-4 py-3 text-left font-semibold text-slate-500">Escenario</th>
-            <th class="px-4 py-3 text-right font-semibold text-slate-500">Actualizado</th>
-          </tr>
-        </thead>
-        <tbody class="divide-y divide-slate-100">
-          ${targets
-            .map((item) => {
-              return `
-                <tr>
-                  <td class="px-4 py-3 text-slate-600">${monthName(item.mes)} ${item.anio}</td>
-                  <td class="px-4 py-3 text-right font-semibold text-slate-800">${formatNumber(item.valor)}</td>
-                  <td class="px-4 py-3 text-slate-500">${item.escenario ?? '—'}</td>
-                  <td class="px-4 py-3 text-right text-slate-400 text-xs">${formatDate(item.fecha_actualizacion ?? item.fecha_ultima_edicion)}</td>
-                </tr>
-              `;
-            })
-            .join('')}
-        </tbody>
-      </table>
-    </div>
-  `;
+function normalizeScenarioValue(value) {
+  return (value ?? '').toString().trim().toUpperCase();
+}
+
+function buildTargetRows(targets, scenario, unitLabel = '') {
+  const normalizedScenario = normalizeScenarioValue(scenario) || SCENARIOS[0];
+  const targetsByMonth = new Map(
+    (targets ?? [])
+      .filter(item => normalizeScenarioValue(item.escenario) === normalizedScenario)
+      .map(item => [Number(item.mes), item])
+  );
+
+  return months
+    .map((month) => {
+      const target = targetsByMonth.get(month.value);
+      const targetValue =
+        target && target.valor !== null && target.valor !== undefined ? target.valor : '';
+      const updatedAt = target?.fecha_actualizacion ?? target?.fecha_captura ?? null;
+      const updatedLabel = updatedAt ? `Actualizado el ${formatDate(updatedAt)}` : '—';
+      const normalizedValue = targetValue !== '' ? targetValue : '';
+
+      return `
+        <tr data-month="${month.value}">
+          <td class="px-4 py-3 text-sm font-medium text-slate-600">${month.label}</td>
+          <td class="px-4 py-3">
+            <div class="flex flex-col gap-2 sm:flex-row sm:items-center">
+              <input
+                type="number"
+                step="0.01"
+                class="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-400"
+                data-month="${month.value}"
+                data-original-value="${normalizedValue}"
+                data-target-id="${target?.id ?? ''}"
+                value="${normalizedValue}"
+                placeholder="Captura la meta${unitLabel ? ` (${unitLabel})` : ''}"
+              />
+            </div>
+          </td>
+          <td class="px-4 py-3 text-right text-xs text-slate-400">${updatedLabel}</td>
+        </tr>
+      `;
+    })
+    .join('');
 }
 
 export async function renderCapture(container) {
@@ -266,7 +274,7 @@ export async function renderCapture(container) {
                 id="year-select"
                 type="number"
                 min="2022"
-                max="2100"
+                max="2032"
                 value="${currentYear}"
                 class="rounded-lg border border-slate-200 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
               />
@@ -448,6 +456,23 @@ async function loadIndicatorContent(container, indicatorId) {
     // Construcción dinámica: solo 1 columna si NO es subdirector, 2 columnas si SÍ es
     const gridClass = esSubdirector ? 'lg:grid-cols-2' : 'lg:grid-cols-1';
 
+    const initialTargetYear = TARGET_YEARS.includes(currentYear)
+      ? currentYear
+      : TARGET_YEARS[0];
+    const firstScenarioWithTargets = (targets ?? []).find(item =>
+      SCENARIOS.includes(normalizeScenarioValue(item.escenario))
+    );
+    const initialTargetScenario = firstScenarioWithTargets
+      ? normalizeScenarioValue(firstScenarioWithTargets.escenario)
+      : SCENARIOS[0];
+    const targetYearOptions = TARGET_YEARS.map(year => `
+      <option value="${year}" ${year === initialTargetYear ? 'selected' : ''}>${year}</option>
+    `).join('');
+    const targetScenarioOptions = SCENARIOS.map(scenario => `
+      <option value="${scenario}" ${scenario === initialTargetScenario ? 'selected' : ''}>${scenario}</option>
+    `).join('');
+    const targetRowsHtml = buildTargetRows(targets, initialTargetScenario, indicator.unidad_medida);
+
     container.innerHTML = `
       <section class="grid gap-6 ${gridClass}">
         <!-- Formulario de medición -->
@@ -528,49 +553,55 @@ async function loadIndicatorContent(container, indicatorId) {
                 <p class="text-xs text-slate-500">${indicator.nombre}</p>
               </div>
             </div>
-            <form id="target-form" class="space-y-4">
+            <form id="target-form" class="space-y-4" data-default-scenario="${initialTargetScenario}">
               <div class="grid gap-4 md:grid-cols-2">
                 <label class="flex flex-col gap-1 text-sm text-slate-600">
-                  Mes
-                  <select name="month" class="rounded-lg border border-slate-200 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-emerald-400">
-                    ${months.map((month) => `<option value="${month.value}">${month.label}</option>`).join('')}
+                  Año
+                  <select name="targetYear" class="rounded-lg border border-slate-200 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-emerald-400">
+                    ${targetYearOptions}
                   </select>
                 </label>
                 <label class="flex flex-col gap-1 text-sm text-slate-600">
                   Escenario
                   <select name="scenario" class="rounded-lg border border-slate-200 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-emerald-400">
-                    ${SCENARIOS.map(s => `<option value="${s}">${s}</option>`).join('')}
+                    ${targetScenarioOptions}
                   </select>
                 </label>
               </div>
-              <label class="flex flex-col gap-1 text-sm text-slate-600">
-                Meta ${indicator.unidad_medida ? `(${indicator.unidad_medida})` : ''}
-                <input
-                  name="value"
-                  type="number"
-                  step="0.01"
-                  required
-                  class="rounded-lg border border-slate-200 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-emerald-400"
-                  placeholder="Ingrese la meta"
-                />
-              </label>
-              <button type="submit" class="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-700">
-                <i class="fa-solid fa-bullseye"></i>
-                Guardar meta
-              </button>
+              <div class="overflow-x-auto rounded-xl border border-slate-200">
+                <table class="min-w-full divide-y divide-slate-200 text-sm">
+                  <thead class="bg-slate-50">
+                    <tr>
+                      <th class="px-4 py-3 text-left font-semibold text-slate-500">Mes</th>
+                      <th class="px-4 py-3 text-left font-semibold text-slate-500">Meta ${indicator.unidad_medida ? `(${indicator.unidad_medida})` : ''}</th>
+                      <th class="px-4 py-3 text-right font-semibold text-slate-500">Última actualización</th>
+                    </tr>
+                  </thead>
+                  <tbody id="target-rows" class="divide-y divide-slate-100">
+                    ${targetRowsHtml}
+                  </tbody>
+                </table>
+              </div>
+              <div class="flex justify-end">
+                <button
+                  type="submit"
+                  id="target-submit"
+                  class="inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-60"
+                  disabled
+                >
+                  <i class="fa-solid fa-floppy-disk"></i>
+                  Actualizar metas
+                </button>
+              </div>
+              <p class="text-[11px] text-slate-400">Se guardarán únicamente los meses con cambios para el escenario seleccionado.</p>
             </form>
-          </div>
-
-          <div class="space-y-3">
-            <h3 class="text-sm font-semibold text-slate-600">Metas registradas</h3>
-            <div id="targets-table">${buildTargetsTable(targets)}</div>
           </div>
         </div>
         ` : ''}
       </section>
     `;
 
-    initializeFormHandlers(indicatorId, esSubdirector, history, container);
+    initializeFormHandlers(indicatorId, esSubdirector, history, container, targets, indicator);
   } catch (error) {
     console.error(error);
     container.innerHTML = '<div class="text-center py-8 text-red-500">Error al cargar el indicador</div>';
@@ -578,12 +609,79 @@ async function loadIndicatorContent(container, indicatorId) {
   }
 }
 
-function initializeFormHandlers(indicatorId, esSubdirector, history, container) {
+function initializeFormHandlers(indicatorId, esSubdirector, history, container, initialTargets = [], indicator = null) {
   const measurementForm = document.getElementById('measurement-form');
   const targetForm = document.getElementById('target-form');
   const historyTable = document.getElementById('history-table');
-  const targetsTable = document.getElementById('targets-table');
   const measurementSubmitLabel = document.getElementById('measurement-submit-label');
+  const targetRows = targetForm?.querySelector('#target-rows');
+  const targetYearSelect = targetForm?.querySelector('select[name="targetYear"]');
+  const targetScenarioSelect = targetForm?.querySelector('select[name="scenario"]');
+  const targetSubmit = targetForm?.querySelector('#target-submit');
+  const indicatorUnit = indicator?.unidad_medida ?? '';
+
+  const targetsCache = new Map();
+  if (Array.isArray(initialTargets)) {
+    const initialYear = targetYearSelect ? Number(targetYearSelect.value) : currentYear;
+    targetsCache.set(initialYear, [...initialTargets]);
+  }
+
+  let selectedTargetYear = targetYearSelect ? Number(targetYearSelect.value) : currentYear;
+  let selectedScenario = targetScenarioSelect
+    ? normalizeScenarioValue(targetScenarioSelect.value || targetForm?.dataset?.defaultScenario)
+    : SCENARIOS[0];
+  if (!selectedScenario) {
+    selectedScenario = SCENARIOS[0];
+  }
+
+  const parseTargetValue = (value) => {
+    const trimmed = (value ?? '').toString().trim();
+    if (trimmed === '') return null;
+    const numeric = Number(trimmed);
+    return Number.isNaN(numeric) ? NaN : numeric;
+  };
+
+  const collectTargetInputs = () =>
+    Array.from(targetForm?.querySelectorAll('input[data-month]') ?? []);
+
+  const hasTargetChanges = () => {
+    const inputs = collectTargetInputs();
+    return inputs.some((input) => {
+      const currentValue = parseTargetValue(input.value);
+      const originalValue = parseTargetValue(input.dataset.originalValue ?? '');
+
+      if (Number.isNaN(currentValue)) {
+        return true;
+      }
+
+      if (currentValue === null && originalValue === null) {
+        return false;
+      }
+
+      return currentValue !== originalValue;
+    });
+  };
+
+  const updateTargetSubmitState = () => {
+    if (!targetSubmit) return;
+    const hasChanges = hasTargetChanges();
+    targetSubmit.disabled = !hasChanges;
+    targetSubmit.classList.toggle('opacity-70', !hasChanges);
+  };
+
+  const attachTargetInputListeners = () => {
+    const inputs = collectTargetInputs();
+    inputs.forEach((input) => {
+      input.addEventListener('input', updateTargetSubmitState);
+    });
+  };
+
+  const renderTargetRows = (targets = []) => {
+    if (!targetRows) return;
+    targetRows.innerHTML = buildTargetRows(targets, selectedScenario, indicatorUnit);
+    attachTargetInputListeners();
+    updateTargetSubmitState();
+  };
 
   const measurementsByMonth = new Map(
     (history ?? [])
@@ -694,36 +792,165 @@ function initializeFormHandlers(indicatorId, esSubdirector, history, container) 
 
   // Handler para formulario de metas (solo si es subdirector)
   if (targetForm && esSubdirector) {
-    targetForm.addEventListener('submit', async (e) => {
-      e.preventDefault();
-      const submit = targetForm.querySelector('button[type="submit"]');
-      submit.disabled = true;
-      submit.classList.add('opacity-70');
+    const ensureTargetsForYear = async (year) => {
+      if (targetsCache.has(year)) {
+        return targetsCache.get(year);
+      }
 
-      const formData = new FormData(targetForm);
-
-      const payload = {
-        indicador_id: indicatorId,
-        anio: currentYear,
-        mes: Number(formData.get('month')),
-        escenario: (formData.get('scenario') ?? '').toString().toUpperCase(),
-        valor: Number(formData.get('value'))
-      };
+      if (targetRows) {
+        targetRows.innerHTML = `
+          <tr>
+            <td colspan="3" class="px-4 py-6 text-center text-sm text-slate-500">
+              Cargando metas del ${year}...
+            </td>
+          </tr>
+        `;
+      }
 
       try {
-        await upsertTarget(payload);
-        showToast('Meta actualizada correctamente');
-        targetForm.reset();
-        
-        // Recargar metas
-        const targets = await getIndicatorTargets(indicatorId, { year: currentYear });
-        targetsTable.innerHTML = buildTargetsTable(targets);
+        const fetchedTargets = await getIndicatorTargets(indicatorId, { year });
+        targetsCache.set(year, [...fetchedTargets]);
+        return fetchedTargets;
       } catch (error) {
         console.error(error);
-        showToast(error.message ?? 'No fue posible actualizar la meta', { type: 'error' });
+        showToast(error.message ?? 'No fue posible obtener las metas del año seleccionado', { type: 'error' });
+        if (targetRows) {
+          targetRows.innerHTML = `
+            <tr>
+              <td colspan="3" class="px-4 py-6 text-center text-sm text-red-500">
+                No fue posible cargar las metas del ${year}.
+              </td>
+            </tr>
+          `;
+        }
+        throw error;
+      }
+    };
+
+    if (targetScenarioSelect) {
+      targetScenarioSelect.value = selectedScenario;
+      targetScenarioSelect.addEventListener('change', () => {
+        selectedScenario = normalizeScenarioValue(targetScenarioSelect.value);
+        if (!selectedScenario) {
+          selectedScenario = SCENARIOS[0];
+        }
+        const yearTargets = targetsCache.get(selectedTargetYear) ?? [];
+        renderTargetRows(yearTargets);
+      });
+    }
+
+    if (targetYearSelect) {
+      targetYearSelect.addEventListener('change', async (event) => {
+        const parsedYear = Number(event.target.value);
+        if (!parsedYear) return;
+        selectedTargetYear = parsedYear;
+
+        try {
+          const yearTargets = await ensureTargetsForYear(selectedTargetYear);
+          renderTargetRows(yearTargets);
+        } catch (error) {
+          console.error(error);
+        }
+      });
+    }
+
+    renderTargetRows(targetsCache.get(selectedTargetYear) ?? []);
+
+    targetForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+
+      const inputs = collectTargetInputs();
+      const changes = inputs
+        .map((input) => {
+          const month = Number(input.dataset.month);
+          const rawValue = (input.value ?? '').toString();
+          const parsedValue = parseTargetValue(rawValue);
+          const originalValue = parseTargetValue(input.dataset.originalValue ?? '');
+          const hasChange =
+            Number.isNaN(parsedValue) || parsedValue !== originalValue;
+
+          return {
+            month,
+            rawValue,
+            value: parsedValue,
+            originalValue,
+            hasChange
+          };
+        })
+        .filter(item => item.month && item.hasChange);
+
+      if (!changes.length) {
+        showToast('No hay cambios por guardar', { type: 'info' });
+        updateTargetSubmitState();
+        return;
+      }
+
+      for (const change of changes) {
+        const trimmed = change.rawValue.toString().trim();
+        if (trimmed === '') {
+          showToast(`Ingresa un valor para la meta de ${monthName(change.month)}`, { type: 'warning' });
+          return;
+        }
+
+        if (Number.isNaN(change.value)) {
+          showToast(`Ingresa un valor numérico válido para la meta de ${monthName(change.month)}`, { type: 'warning' });
+          return;
+        }
+      }
+
+      const originalContent = targetSubmit ? targetSubmit.innerHTML : '';
+      if (targetSubmit) {
+        targetSubmit.disabled = true;
+        targetSubmit.classList.add('opacity-70');
+        targetSubmit.innerHTML = '<i class="fa-solid fa-spinner fa-spin"></i> Guardando...';
+      }
+
+      let yearTargets = targetsCache.get(selectedTargetYear) ?? [];
+
+      try {
+        for (const change of changes) {
+          const payload = {
+            indicador_id: indicatorId,
+            anio: selectedTargetYear,
+            mes: change.month,
+            escenario: selectedScenario,
+            valor: change.value
+          };
+
+          const updatedTarget = await upsertTarget(payload);
+
+          const normalizedScenario = normalizeScenarioValue(updatedTarget.escenario);
+          const monthValue = Number(change.month);
+          const existingIndex = yearTargets.findIndex(
+            item =>
+              Number(item.mes) === monthValue &&
+              normalizeScenarioValue(item.escenario) === normalizedScenario
+          );
+
+          if (existingIndex >= 0) {
+            yearTargets = [
+              ...yearTargets.slice(0, existingIndex),
+              updatedTarget,
+              ...yearTargets.slice(existingIndex + 1)
+            ];
+          } else {
+            yearTargets = [...yearTargets, updatedTarget];
+          }
+        }
+
+        targetsCache.set(selectedTargetYear, yearTargets);
+        renderTargetRows(yearTargets);
+        showToast('Metas actualizadas correctamente');
+      } catch (error) {
+        console.error(error);
+        showToast(error.message ?? 'No fue posible actualizar las metas', { type: 'error' });
       } finally {
-        submit.disabled = false;
-        submit.classList.remove('opacity-70');
+        if (targetSubmit) {
+          targetSubmit.disabled = false;
+          targetSubmit.classList.remove('opacity-70');
+          targetSubmit.innerHTML = originalContent;
+          updateTargetSubmitState();
+        }
       }
     });
   }


### PR DESCRIPTION
## Summary
- redesign the meta editor to use a single save button with change detection for monthly targets
- track original target values so the update button stays disabled until modifications and batches updates
- keep the capture helpers consistent with the new workflow when switching year/scenario

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3e7bbd2b8832e8135bec7feb9190c