### PR TITLE
Adjust SMS subdirection label to Gerencias

### DIFF
--- a/src/views/dashboard.js
+++ b/src/views/dashboard.js
@@ -1679,10 +1679,23 @@ function extractDirectionRoots(tree) {
   return directions;
 }
 
-function buildDirectionPanelContent() {
+function getDirectionChildrenLabel(direction) {
+  const name = direction?.nombre?.toLowerCase?.() ?? '';
+  const key = direction?.clave?.toLowerCase?.() ?? '';
+
+  if (name.includes('sms') || key === 'sms') {
+    return 'Gerencias';
+  }
+
+  return 'Subdirecciones';
+}
+
+function buildDirectionPanelContent(direction) {
+  const label = getDirectionChildrenLabel(direction);
+
   return `
     <div class="space-y-3">
-      <p class="text-sm font-medium text-slate-700">Subdirecciones</p>
+      <p class="text-sm font-medium text-slate-700">${escapeHtml(label)}</p>
       <ul class="space-y-2"></ul>
     </div>
   `;


### PR DESCRIPTION
## Summary
- adjust the dashboard direction panel to show "Gerencias" instead of "Subdirecciones" when the section corresponds to the SMS subdirection

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e460823ce4832ea119402e92afc54c